### PR TITLE
add explicit MacroDataset merge support

### DIFF
--- a/deepmimo/datasets/dataset.py
+++ b/deepmimo/datasets/dataset.py
@@ -1798,6 +1798,183 @@ class Dataset(DotDict):
     }
 
 
+_MERGE_EXCLUDED_KEYS = {"n_ue", "grid_size", "grid_spacing"}
+
+
+class MergedGridDataset(Dataset):
+    """Dataset wrapper that resolves global row/col indexing across merged RX grids."""
+
+    def __init__(self, data: dict[str, Any] | None = None, *, merge_spec: dict[str, Any]) -> None:
+        """Initialize a merged dataset with precomputed global grid metadata."""
+        super().__init__(data or {})
+        object.__setattr__(self, "_merge_spec", merge_spec)
+
+    def _resolve_global_grid_idxs(
+        self,
+        axis: str,
+        idxs: int | list[int] | np.ndarray,
+    ) -> np.ndarray:
+        """Resolve global merged-grid row/column indices into user indices."""
+        idxs_arr = np.asarray([idxs] if isinstance(idxs, int) else idxs, dtype=int).ravel()
+        if idxs_arr.size == 0:
+            return np.array([], dtype=int)
+
+        if axis == "row":
+            grid_offsets = np.asarray(self._merge_spec["row_offsets"], dtype=int)
+        elif axis == "col":
+            grid_offsets = np.asarray(self._merge_spec["col_offsets"], dtype=int)
+        else:
+            msg = f"Invalid axis '{axis}', must be 'row' or 'col'"
+            raise ValueError(msg)
+
+        if np.any(idxs_arr < 0) or np.any(idxs_arr >= grid_offsets[-1]):
+            msg = (
+                f"{axis}_idxs must be in range [0, {grid_offsets[-1]}), "
+                f"but got min={idxs_arr.min()}, max={idxs_arr.max()}"
+            )
+            raise IndexError(msg)
+
+        ue_offsets = np.asarray(self._merge_spec["ue_offsets"], dtype=int)
+        grid_sizes = [np.asarray(g, dtype=int) for g in self._merge_spec["grid_sizes"]]
+
+        grid_idxs = np.searchsorted(grid_offsets[1:], idxs_arr, side="right")
+        all_ue_idxs = []
+        for idx, grid_idx in zip(idxs_arr, grid_idxs, strict=False):
+            local_idx = int(idx - grid_offsets[grid_idx])
+            local_ue_idxs = get_grid_idxs(grid_sizes[grid_idx], axis, np.array([local_idx]))
+            all_ue_idxs.append(local_ue_idxs + ue_offsets[grid_idx])
+
+        return np.concatenate(all_ue_idxs).astype(int)
+
+    def _get_row_idxs(self, row_idxs: int | list[int] | np.ndarray) -> np.ndarray:
+        """Return indices of users in global merged rows."""
+        return self._resolve_global_grid_idxs("row", row_idxs)
+
+    def _get_col_idxs(self, col_idxs: int | list[int] | np.ndarray) -> np.ndarray:
+        """Return indices of users in global merged columns."""
+        return self._resolve_global_grid_idxs("col", col_idxs)
+
+
+def _pad_concat_users(arrays: list[np.ndarray]) -> np.ndarray:
+    """Pad per-user arrays to common non-user dimensions, then concatenate on axis 0."""
+    ndim = arrays[0].ndim
+    target_shape = [max(arr.shape[d] for arr in arrays) for d in range(1, ndim)]
+    padded_arrays = []
+    for arr in arrays:
+        arr_to_pad = arr
+        if np.issubdtype(arr_to_pad.dtype, np.integer) or np.issubdtype(arr_to_pad.dtype, np.bool_):
+            arr_to_pad = arr_to_pad.astype(np.float32)
+
+        pad_width = [(0, 0)] + [
+            (0, target_shape[d - 1] - arr_to_pad.shape[d]) for d in range(1, ndim)
+        ]
+        if np.issubdtype(arr_to_pad.dtype, np.complexfloating):
+            pad_value = np.nan + 0j
+        elif np.issubdtype(arr_to_pad.dtype, np.floating):
+            pad_value = np.nan
+        else:
+            pad_value = 0
+        padded_arrays.append(
+            np.pad(arr_to_pad, pad_width, mode="constant", constant_values=pad_value)
+        )
+    return np.concatenate(padded_arrays, axis=0)
+
+
+def _merged_grid_spec(datasets: list[Dataset]) -> dict[str, Any]:
+    """Build global row/col indexing metadata for merged multi-grid datasets."""
+    grid_sizes = [np.asarray(ds.grid_size, dtype=int) for ds in datasets]
+    ue_offsets = np.cumsum([0, *[int(ds.n_ue) for ds in datasets[:-1]]], dtype=int)
+    n_rows_per_grid = [int(grid_size[1]) for grid_size in grid_sizes]
+    n_cols_per_grid = [int(grid_size[0]) for grid_size in grid_sizes]
+    return {
+        "ue_offsets": ue_offsets,
+        "grid_sizes": grid_sizes,
+        "row_offsets": np.cumsum([0, *n_rows_per_grid], dtype=int),
+        "col_offsets": np.cumsum([0, *n_cols_per_grid], dtype=int),
+    }
+
+
+def merge_datasets(datasets: list[Dataset]) -> Dataset:  # noqa: C901, PLR0912
+    """Merge datasets that share one transmitter into an explicit merged-grid dataset."""
+    if not datasets:
+        msg = "Cannot merge an empty dataset list"
+        raise ValueError(msg)
+
+    if len(datasets) == 1:
+        return datasets[0]
+
+    tx_keys = {
+        (
+            int(dataset.get("txrx", {}).get("tx_set_id", -1)),
+            int(dataset.get("txrx", {}).get("tx_idx", -1)),
+        )
+        for dataset in datasets
+    }
+    rx_set_ids = {int(dataset.get("txrx", {}).get("rx_set_id", -1)) for dataset in datasets}
+    if len(tx_keys) != 1:
+        if len(rx_set_ids) == 1:
+            msg = (
+                "Merging datasets across multiple transmitters is not supported yet because "
+                "Dataset operations assume a single transmitter view."
+            )
+            raise NotImplementedError(msg)
+        msg = "Selected datasets must share the same transmitter or the same receiver grid"
+        raise ValueError(msg)
+
+    merged_data: dict[str, Any] = {}
+    keys: list[str] = []
+    seen: set[str] = set()
+    for dataset in datasets:
+        for key in dataset:
+            if key in _MERGE_EXCLUDED_KEYS or key in seen:
+                continue
+            seen.add(key)
+            keys.append(key)
+
+    for key in keys:
+        present_values = [dataset[key] for dataset in datasets if dataset.hasattr(key)]
+        present_datasets = [dataset for dataset in datasets if dataset.hasattr(key)]
+        if not present_values:
+            continue
+        first_value = present_values[0]
+
+        if len(present_values) != len(datasets):
+            merged_data[key] = first_value
+            continue
+
+        is_per_user_array = (
+            isinstance(first_value, np.ndarray)
+            and first_value.ndim > 0
+            and all(
+                isinstance(value, np.ndarray) and value.ndim == first_value.ndim
+                for value in present_values
+            )
+            and all(
+                value.shape[0] == dataset.n_ue
+                for value, dataset in zip(present_values, present_datasets, strict=False)
+            )
+        )
+
+        if is_per_user_array:
+            same_tail_shapes = all(
+                value.shape[1:] == present_values[0].shape[1:] for value in present_values
+            )
+            if same_tail_shapes:
+                merged_data[key] = np.concatenate(present_values, axis=0)
+            else:
+                merged_data[key] = _pad_concat_users(present_values)
+        else:
+            merged_data[key] = first_value
+
+    merged_data["txrx_parts"] = [
+        dict(dataset.txrx) for dataset in datasets if dataset.hasattr("txrx")
+    ]
+    if datasets[0].hasattr("txrx"):
+        merged_data["txrx"] = dict(datasets[0].txrx)
+
+    return MergedGridDataset(merged_data, merge_spec=_merged_grid_spec(datasets))
+
+
 class MacroDataset:
     """Container holding multiple datasets and propagating operations to each.
 
@@ -1864,21 +2041,46 @@ class MacroDataset:
         results = [getattr(dataset, name) for dataset in self.datasets]
         return results[0] if len(results) == 1 else results
 
+    def _subset(self, idxs: list[int]) -> MacroDataset:
+        """Return a MacroDataset view preserving the requested dataset order."""
+        subset = MacroDataset([self.datasets[idx] for idx in idxs])
+        for attr, value in self.__dict__.items():
+            if attr != "datasets":
+                setattr(subset, attr, value)
+        return subset
+
+    def _normalize_dataset_indices(self, idx: Any) -> list[int]:
+        """Normalize multi-index selection into an ordered list of dataset indices."""
+        if isinstance(idx, tuple):
+            idx = list(idx)
+        if isinstance(idx, list):
+            return [int(i) for i in idx]
+        if isinstance(idx, np.ndarray):
+            if idx.dtype == bool:
+                return np.flatnonzero(idx).tolist()
+            return np.asarray(idx, dtype=int).ravel().tolist()
+        msg = "MacroDataset indices must be int, slice, str, or an ordered collection of integers"
+        raise TypeError(msg)
+
     def __getitem__(self, idx: Any) -> Any:
-        """Get dataset at specified index if idx is integer, otherwise propagate to all datasets.
+        """Get one dataset, a dataset subset, or a propagated attribute.
 
         Args:
-            idx: Integer index to get specific dataset, or string key to get attribute
-                from all datasets
+            idx: Integer index to get a specific dataset, slice/sequence of indices to
+                get a MacroDataset subset, or string key to get an attribute from all
+                datasets.
 
         Returns:
-            Dataset instance if idx is integer,
-            single value if idx is in SHARED_PARAMS or if there is only one dataset,
-            or list of results if idx is string and there are multiple datasets
+            Dataset instance if idx is integer, MacroDataset subset if idx selects
+            multiple datasets, or propagated attribute values for string keys.
 
         """
-        if isinstance(idx, (int, slice)):
-            return self.datasets[idx]
+        if isinstance(idx, (int, np.integer)):
+            return self.datasets[int(idx)]
+        if isinstance(idx, slice):
+            return self._subset(list(range(*idx.indices(len(self.datasets)))))
+        if isinstance(idx, (tuple, list, np.ndarray)):
+            return self._subset(self._normalize_dataset_indices(idx))
         if idx in SHARED_PARAMS:
             return self._get_single(idx)
         results = [dataset[idx] for dataset in self.datasets]
@@ -1907,6 +2109,19 @@ class MacroDataset:
 
         """
         self.datasets.append(dataset)
+
+    def merge(self) -> Dataset:
+        """Merge selected datasets into one explicit merged-grid dataset.
+
+        The selected datasets must currently share the same transmitter. The merge
+        preserves the caller-provided dataset order and creates global row/column
+        indexing across the merged receiver grids.
+
+        Returns:
+            Dataset: The merged dataset view.
+
+        """
+        return merge_datasets(self.datasets)
 
     def to_binary(self, output_dir: str = "./datasets") -> None:
         """Export all datasets to binary format for web visualizer.

--- a/deepmimo/datasets/dataset.py
+++ b/deepmimo/datasets/dataset.py
@@ -1798,7 +1798,7 @@ class Dataset(DotDict):
     }
 
 
-_MERGE_EXCLUDED_KEYS = {"n_ue", "grid_size", "grid_spacing"}
+_MERGE_EXCLUDED_KEYS = {"n_ue", "grid_size", "grid_spacing", "txrx"}
 
 
 class MergedGridDataset(Dataset):
@@ -1880,6 +1880,21 @@ def _pad_concat_users(arrays: list[np.ndarray]) -> np.ndarray:
     return np.concatenate(padded_arrays, axis=0)
 
 
+def _missing_user_array(n_ue: int, tail_shape: tuple[int, ...], dtype: np.dtype) -> np.ndarray:
+    """Return a padded placeholder for a missing per-user array."""
+    array_dtype = np.dtype(dtype)
+    if np.issubdtype(array_dtype, np.integer) or np.issubdtype(array_dtype, np.bool_):
+        array_dtype = np.dtype(np.float32)
+
+    if np.issubdtype(array_dtype, np.complexfloating):
+        fill_value = np.nan + 0j
+    elif np.issubdtype(array_dtype, np.floating):
+        fill_value = np.nan
+    else:
+        fill_value = 0
+    return np.full((n_ue, *tail_shape), fill_value, dtype=array_dtype)
+
+
 def _merged_grid_spec(datasets: list[Dataset]) -> dict[str, Any]:
     """Build global row/col indexing metadata for merged multi-grid datasets."""
     grid_sizes = [np.asarray(ds.grid_size, dtype=int) for ds in datasets]
@@ -1938,10 +1953,6 @@ def merge_datasets(datasets: list[Dataset]) -> Dataset:  # noqa: C901, PLR0912
             continue
         first_value = present_values[0]
 
-        if len(present_values) != len(datasets):
-            merged_data[key] = first_value
-            continue
-
         is_per_user_array = (
             isinstance(first_value, np.ndarray)
             and first_value.ndim > 0
@@ -1954,6 +1965,25 @@ def merge_datasets(datasets: list[Dataset]) -> Dataset:  # noqa: C901, PLR0912
                 for value, dataset in zip(present_values, present_datasets, strict=False)
             )
         )
+
+        if len(present_values) != len(datasets):
+            if is_per_user_array:
+                tail_shape = tuple(
+                    max(value.shape[dim] for value in present_values)
+                    for dim in range(1, first_value.ndim)
+                )
+                aligned_values = []
+                for dataset in datasets:
+                    if dataset.hasattr(key):
+                        aligned_values.append(dataset[key])
+                    else:
+                        aligned_values.append(
+                            _missing_user_array(int(dataset.n_ue), tail_shape, first_value.dtype)
+                        )
+                merged_data[key] = _pad_concat_users(aligned_values)
+            else:
+                merged_data[key] = first_value
+            continue
 
         if is_per_user_array:
             same_tail_shapes = all(
@@ -2043,7 +2073,14 @@ class MacroDataset:
 
     def _subset(self, idxs: list[int]) -> MacroDataset:
         """Return a MacroDataset view preserving the requested dataset order."""
-        subset = MacroDataset([self.datasets[idx] for idx in idxs])
+        subset_datasets = [self.datasets[idx] for idx in idxs]
+        if isinstance(self, DynamicDataset):
+            subset = DynamicDataset(subset_datasets, self.name)
+            if hasattr(self, "timestamps"):
+                subset.timestamps = np.asarray(self.timestamps)[idxs]
+            return subset
+
+        subset = MacroDataset(subset_datasets)
         for attr, value in self.__dict__.items():
             if attr != "datasets":
                 setattr(subset, attr, value)

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -156,11 +156,11 @@ into one merged-grid view:
 ```python
 raw = dm.load("O1_60", tx_sets=[0], rx_sets=[0, 1, 2])
 
-merged = raw[0, 1, 2].merge()
+# Merge all loaded datasets
+merged_all = raw.merge()
 
-# Global merged row/column indexing follows the selected dataset order
-row_idxs = merged.get_idxs("row", row_idxs=[0, 2, 6])
-col_idxs = merged.get_idxs("col", col_idxs=[0, 3, 5])
+# Merge only a selected subset, preserving the requested order
+merged_subset = raw[0, 2].merge()
 ```
 
 ::: deepmimo.datasets.dataset.MacroDataset

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -19,7 +19,7 @@ deepmimo/datasets/
 import deepmimo as dm
 
 # Load a scenario
-dataset = dm.load('asu_campus_3p5')
+dataset = dm.load("asu_campus_3p5")
 ```
 
 !!! tip "Detailed load examples"
@@ -37,9 +37,9 @@ import deepmimo as dm
 
 # Generate dataset with custom parameters
 dataset = dm.generate(
-    'asu_campus_3p5',
-    load_params={'tx_sets': [0], 'rx_sets': [0]},
-    ch_params={'bs_antenna': {'shape': [8, 1]}}
+    "asu_campus_3p5",
+    load_params={"tx_sets": [0], "rx_sets": [0]},
+    ch_params={"bs_antenna": {"shape": [8, 1]}},
 )
 ```
 
@@ -54,7 +54,7 @@ The `Dataset` class represents a single dataset within DeepMIMO, containing tran
 import deepmimo as dm
 
 # Load a dataset
-dataset = dm.load('scenario_name')
+dataset = dm.load("scenario_name")
 
 # Access transmitter data
 tx_locations = dataset.tx_locations
@@ -91,13 +91,13 @@ channels = dataset.channels  # If already computed
 Unified index selection (dispatcher):
 ```python
 # Uniform sampling on the grid
-uniform_idxs = dataset.get_idxs('uniform', steps=[2, 2])
+uniform_idxs = dataset.get_idxs("uniform", steps=[2, 2])
 
 # Active users (paths > 0)
-active_idxs = dataset.get_idxs('active')
+active_idxs = dataset.get_idxs("active")
 
 # Users along a line
-linear_idxs = dataset.get_idxs('linear', start_pos=[0,0,0], end_pos=[100,0,0], n_steps=50)
+linear_idxs = dataset.get_idxs("linear", start_pos=[0, 0, 0], end_pos=[100, 0, 0], n_steps=50)
 ```
 
 Create trimmed datasets (physical trimming):
@@ -109,12 +109,7 @@ dataset2 = dataset.trim(idxs=uniform_idxs)
 dataset_fov = dataset.trim(bs_fov=[90, 90])  # optional: ue_fov=[...]
 
 # Combine trims efficiently (order: idxs -> FoV -> path depth -> path type)
-dataset_t = dataset.trim(
-    idxs=active_idxs,
-    bs_fov=[90, 90],
-    path_depth=1,
-    path_types=['LoS', 'R']
-)
+dataset_t = dataset.trim(idxs=active_idxs, bs_fov=[90, 90], path_depth=1, path_types=["LoS", "R"])
 ```
 
 !!! tip "User sampling and subsets"
@@ -145,6 +140,7 @@ The `MacroDataset` class is a container for managing multiple datasets, providin
 # Access individual datasets
 dataset = macro_dataset[0]  # First dataset
 datasets = macro_dataset[1:3]  # Slice of datasets
+ordered_subset = macro_dataset[0, 2, 1]  # Preserve explicit dataset order
 
 # Iterate over datasets
 for dataset in macro_dataset:
@@ -152,6 +148,19 @@ for dataset in macro_dataset:
 
 # Batch operations
 channels = macro_dataset.compute_channels()
+```
+
+For scenarios with multiple RX grids, you can explicitly merge selected datasets
+into one merged-grid view:
+
+```python
+raw = dm.load("O1_60", tx_sets=[0], rx_sets=[0, 1, 2])
+
+merged = raw[0, 1, 2].merge()
+
+# Global merged row/column indexing follows the selected dataset order
+row_idxs = merged.get_idxs("row", row_idxs=[0, 2, 6])
+col_idxs = merged.get_idxs("col", col_idxs=[0, 3, 5])
 ```
 
 ::: deepmimo.datasets.dataset.MacroDataset
@@ -162,10 +171,12 @@ The `DynamicDataset` class extends `MacroDataset` to handle multiple time snapsh
 
 ```python
 # Convert a dynamic dataset
-dm.convert(rt_folder) # rt_folder must contain individual folders of ray tracing results
+dm.convert(rt_folder)  # rt_folder must contain individual folders of ray tracing results
 
 # Load a dynamic dataset
-dynamic_dataset = dm.load('scenario_name')  # Returns DynamicDataset if multiple time snapshots exist
+dynamic_dataset = dm.load(
+    "scenario_name"
+)  # Returns DynamicDataset if multiple time snapshots exist
 
 # Access individual time snapshots
 snapshot = dynamic_dataset[0]  # First time snapshot
@@ -193,14 +204,14 @@ Get dataset summary statistics:
 ```python
 import deepmimo as dm
 
-# Get summary as a string
-summary_str = dm.summary('scenario_name', print_summary=False)
+# Get scenario summary
+dm.summary('scenario_name')
 
 # Get detailed stats for selected TX/RX sets
-stats_str = dm.stats('scenario_name', tx_sets=[4], print_summary=False)
+dm.stats('scenario_name', tx_sets=[4])
 
 # Plot summary
-dm.plot_summary('scenario_name')
+dm.plot_summary("scenario_name")
 ```
 
 ::: deepmimo.datasets.summary.summary
@@ -219,7 +230,7 @@ Utilities for selecting user indices:
 idxs = dm.get_uniform_idxs(n_ue=1000, grid_size=[10, 10], steps=[2, 2])
 
 # Linear sampling
-idxs = dm.get_linear_idxs(rx_pos, start_pos=[0,0,0], end_pos=[100,0,0], n_steps=50)
+idxs = dm.get_linear_idxs(rx_pos, start_pos=[0, 0, 0], end_pos=[100, 0, 0], n_steps=50)
 
 # Grid sampling
 idxs = dm.get_grid_idxs(grid_size=[10, 10], rows=[0, 1, 2], cols=[0, 1, 2])

--- a/docs/tutorials/4_dataset_manipulation.py
+++ b/docs/tutorials/4_dataset_manipulation.py
@@ -10,6 +10,7 @@
 #
 # **Tutorial Overview:**
 # - Dataset Trimming - Trim dataset based on conditions
+# - Merging RX Grids - Combine selected datasets into one merged-grid view
 # - Uniform Sampling - Uniform user sampling
 # - Linear Sampling - Linear user placement
 # - Rectangular Zones - Filtering in 3D bounding boxes
@@ -33,6 +34,44 @@ dm.download(scen_name)
 dataset = dm.load(scen_name)
 
 print(f"Original dataset size: {len(dataset.power)} users")
+
+# %% [markdown]
+# ## Merging RX Grids
+#
+# Some scenarios load as a `MacroDataset`, where each element corresponds to one
+# TX/RX pair. When multiple receiver grids share the same transmitter, you can
+# merge them into one explicit merged-grid dataset.
+
+# %%
+multi_grid_scen = "city_0_newyork_3p5"
+dm.download(multi_grid_scen)
+
+multi_grid = dm.load(
+    multi_grid_scen,
+    tx_sets=[1],
+    rx_sets="all",
+    matrices=["rx_pos", "tx_pos", "power", "phase", "delay", "aoa_az", "inter", "inter_pos"],
+)
+
+print(f"Loaded object type: {type(multi_grid).__name__}")
+print(f"Loaded TX/RX pairs: {len(multi_grid)}")
+print(f"Pair IDs: {multi_grid.txrx}")
+
+# %%
+# Merge all loaded datasets
+merged_all = multi_grid.merge()
+print(f"Merged-all type: {type(merged_all).__name__}")
+print(f"Merged-all users: {merged_all.n_ue}")
+print(f"Merged-all grid size: {merged_all.grid_size}")
+
+# %%
+# Merge only a selected subset, preserving the requested order
+merged_subset = multi_grid[0, 2].merge()
+subset_row_idxs = merged_subset.get_idxs("row", row_idxs=[0])
+
+print(f"Merged-subset users: {merged_subset.n_ue}")
+print(f"Merged-subset grid size: {merged_subset.grid_size}")
+print(f"Users in first merged row: {len(subset_row_idxs)}")
 
 # %% [markdown]
 # ## Dataset Trimming

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -194,6 +194,26 @@ def test_dynamic_dataset() -> None:
     assert np.allclose(ds1.rx_vel, 1.0)
 
 
+def test_dynamic_dataset_subset_preserves_dynamic_type() -> None:
+    """Selecting multiple snapshots should preserve the DynamicDataset wrapper."""
+    snapshot1 = MacroDataset([Dataset({"rx_pos": np.zeros((1, 3)), "tx_pos": np.zeros((1, 3))})])
+    snapshot2 = MacroDataset([Dataset({"rx_pos": np.ones((1, 3)), "tx_pos": np.ones((1, 3))})])
+    snapshot3 = MacroDataset(
+        [Dataset({"rx_pos": np.full((1, 3), 2.0), "tx_pos": np.zeros((1, 3))})]
+    )
+    snapshot1.name = "s1"
+    snapshot2.name = "s2"
+    snapshot3.name = "s3"
+    dyn = DynamicDataset([snapshot1, snapshot2, snapshot3], name="test_dyn")
+    dyn.timestamps = np.array([0.0, 1.0, 2.0])
+
+    subset = dyn[0:2]
+
+    assert isinstance(subset, DynamicDataset)
+    assert subset.n_scenes == 2
+    np.testing.assert_array_equal(subset.timestamps, np.array([0.0, 1.0]))
+
+
 def test_compute_num_interactions() -> None:
     """Test interactions computation logic."""
     ds = Dataset({"n_ue": 2})  # Need n_ue for Dataset
@@ -302,8 +322,10 @@ def test_macro_dataset_merge_handles_asymmetric_keys() -> None:
 
     assert "grid1_only" in merged
     assert "grid2_only" in merged
-    np.testing.assert_array_equal(merged["grid1_only"], g1["grid1_only"])
-    np.testing.assert_array_equal(merged["grid2_only"], g2["grid2_only"])
+    np.testing.assert_array_equal(merged["grid1_only"][: g1.n_ue], g1["grid1_only"])
+    np.testing.assert_array_equal(merged["grid2_only"][g1.n_ue :], g2["grid2_only"])
+    assert np.all(np.isnan(merged["grid1_only"][g1.n_ue :]))
+    assert np.all(np.isnan(merged["grid2_only"][: g1.n_ue]))
 
 
 def test_macro_dataset_merge_ignores_stale_cached_n_ue() -> None:

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from deepmimo import consts as c
-from deepmimo.datasets.dataset import Dataset, DynamicDataset, MacroDataset
+from deepmimo.datasets.dataset import Dataset, DynamicDataset, MacroDataset, MergedGridDataset
 from deepmimo.datasets.load import _validate_txrx_sets
 
 
@@ -234,6 +234,103 @@ def test_get_idxs(sample_dataset) -> None:
     # Invalid mode
     with pytest.raises(ValueError, match="Unknown mode"):
         ds.get_idxs("invalid_mode")
+
+
+def _make_grid_dataset(nx: int, ny: int, tx_set_id: int, tx_idx: int, rx_set_id: int) -> Dataset:
+    """Create a synthetic grid dataset with x-fastest ordering."""
+    rx_pos = np.array([[x, y, 0.0] for y in range(ny) for x in range(nx)], dtype=float)
+    n_ue = nx * ny
+    return Dataset(
+        {
+            "rx_pos": rx_pos,
+            "tx_pos": np.array([0.0, 0.0, 10.0], dtype=float),
+            "power": np.zeros((n_ue, 2), dtype=float),
+            "phase": np.zeros((n_ue, 2), dtype=float),
+            "delay": np.zeros((n_ue, 2), dtype=float),
+            "aoa_az": np.zeros((n_ue, 2), dtype=float),
+            "aoa_el": np.zeros((n_ue, 2), dtype=float),
+            "aod_az": np.zeros((n_ue, 2), dtype=float),
+            "aod_el": np.zeros((n_ue, 2), dtype=float),
+            "inter": np.zeros((n_ue, 2), dtype=float),
+            "inter_pos": np.zeros((n_ue, 2, 1, 3), dtype=float),
+            "txrx": {"tx_set_id": tx_set_id, "tx_idx": tx_idx, "rx_set_id": rx_set_id},
+        }
+    )
+
+
+def _make_macro_dataset(*datasets: Dataset) -> MacroDataset:
+    """Create a MacroDataset for merge tests."""
+    return MacroDataset(list(datasets))
+
+
+def test_macro_dataset_multi_index_returns_ordered_subset() -> None:
+    """Selecting multiple indices should return a MacroDataset in the requested order."""
+    g1 = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=0)
+    g2 = _make_grid_dataset(nx=4, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=1)
+    g3 = _make_grid_dataset(nx=2, ny=3, tx_set_id=0, tx_idx=0, rx_set_id=2)
+    macro = _make_macro_dataset(g1, g2, g3)
+
+    subset = macro[0, 2, 1]
+
+    assert isinstance(subset, MacroDataset)
+    assert subset[0] is g1
+    assert subset[1] is g3
+    assert subset[2] is g2
+
+
+def test_macro_dataset_merge_native_preserves_selected_grid_order() -> None:
+    """Native merges should use the requested dataset order and native row/col semantics."""
+    g1 = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=0)
+    g2 = _make_grid_dataset(nx=4, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=1)
+    macro = _make_macro_dataset(g1, g2)
+
+    merged = macro[1, 0].merge()
+
+    assert isinstance(merged, MergedGridDataset)
+    row_idxs = merged.get_idxs("row", row_idxs=np.array([0, 2]))
+    np.testing.assert_array_equal(row_idxs, np.array([0, 1, 2, 3, 8, 9, 10]))
+
+def test_macro_dataset_merge_handles_asymmetric_keys() -> None:
+    """Merging should not fail when RX-grid datasets have non-uniform keys."""
+    g1 = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=0)
+    g2 = _make_grid_dataset(nx=4, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=1)
+    g1["grid1_only"] = np.ones((g1.n_ue, 1), dtype=float)
+    g2["grid2_only"] = np.zeros((g2.n_ue, 1), dtype=float)
+    macro = _make_macro_dataset(g1, g2)
+
+    merged = macro.merge()
+
+    assert "grid1_only" in merged
+    assert "grid2_only" in merged
+    np.testing.assert_array_equal(merged["grid1_only"], g1["grid1_only"])
+    np.testing.assert_array_equal(merged["grid2_only"], g2["grid2_only"])
+
+
+def test_macro_dataset_merge_ignores_stale_cached_n_ue() -> None:
+    """Repeated merges should not inherit a stale n_ue key from child dataset caches."""
+    g1 = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=0)
+    g2 = _make_grid_dataset(nx=4, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=1)
+    macro = _make_macro_dataset(g1, g2)
+
+    first_merge = macro.merge()
+    assert first_merge.n_ue == g1.n_ue + g2.n_ue
+
+    second_merge = macro.merge()
+    assert second_merge.n_ue == g1.n_ue + g2.n_ue
+    assert second_merge.rx_pos.shape[0] == g1.n_ue + g2.n_ue
+
+    subset_merge = macro[0, 1].merge()
+    assert subset_merge.n_ue == g1.n_ue + g2.n_ue
+
+
+def test_macro_dataset_merge_rejects_multiple_transmitters() -> None:
+    """Merging multiple transmitters should fail until Dataset supports that view explicitly."""
+    g1 = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=0)
+    g2 = _make_grid_dataset(nx=3, ny=2, tx_set_id=1, tx_idx=0, rx_set_id=0)
+    macro = _make_macro_dataset(g1, g2)
+
+    with pytest.raises(NotImplementedError, match="multiple transmitters"):
+        macro.merge()
 
 
 def test_validate_txrx_sets_orders_allowed_ids_deterministically() -> None:

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -310,6 +310,7 @@ def test_macro_dataset_merge_native_preserves_selected_grid_order() -> None:
     row_idxs = merged.get_idxs("row", row_idxs=np.array([0, 2]))
     np.testing.assert_array_equal(row_idxs, np.array([0, 1, 2, 3, 8, 9, 10]))
 
+
 def test_macro_dataset_merge_handles_asymmetric_keys() -> None:
     """Merging should not fail when RX-grid datasets have non-uniform keys."""
     g1 = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=0)


### PR DESCRIPTION
## Summary
- add ordered `MacroDataset` subset selection for expressions like `dataset[0, 2, 1]`
- add a native `MacroDataset.merge()` operation that builds one merged-grid dataset view
- keep this PR focused on generic merge behavior and leave legacy indexing compatibility for a follow-up MR

## Test plan
- [x] `uv run pytest tests/datasets/test_dataset.py`

Made with [Cursor](https://cursor.com)