### PR TITLE
Add compat_v3 load mode for v3 migration indexing

### DIFF
--- a/deepmimo/datasets/compat_v3.py
+++ b/deepmimo/datasets/compat_v3.py
@@ -1,0 +1,65 @@
+"""Backward-compatibility helpers for v3-style merged-grid loading."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from deepmimo.datasets.dataset import Dataset, MacroDataset, merge_datasets
+
+
+def _rx_rank_map(txrx_dict: dict[str, Any]) -> dict[int, int]:
+    """Map RX set IDs to their scenario order rank using numeric sorting."""
+    rx_sets = [txrx_dict[key] for key in sorted(txrx_dict.keys()) if txrx_dict[key]["is_rx"]]
+    rx_set_ids = sorted(int(rx_set["id"]) for rx_set in rx_sets)
+    return {rx_set_id: rank for rank, rx_set_id in enumerate(rx_set_ids)}
+
+
+def _v3_grid_axes(
+    datasets: list[Dataset],
+    rx_rank_map: dict[int, int],
+) -> tuple[list[str], list[str]]:
+    """Return v3 row/col axis overrides for the provided RX-grid datasets."""
+    if not rx_rank_map:
+        msg = (
+            "V3 compatibility requires RX rank metadata. Load the dataset through "
+            "`dm.load(..., compat_v3=True)` or pass a non-empty rank map."
+        )
+        raise ValueError(msg)
+
+    rx_set_ids = [int(ds.get("txrx", {}).get("rx_set_id", -1)) for ds in datasets]
+    row_axes = ["row" if rx_rank_map.get(rx_set_id, 0) == 0 else "col" for rx_set_id in rx_set_ids]
+    col_axes = ["col" if rx_rank_map.get(rx_set_id, 0) == 0 else "row" for rx_set_id in rx_set_ids]
+    return row_axes, col_axes
+
+
+def _merge_rx_grids_v3(
+    datasets: list[Dataset],
+    rx_rank_map: dict[int, int],
+) -> Dataset:
+    """Merge RX-grid datasets for one TX into a v3-compatible merged view."""
+    row_axes, col_axes = _v3_grid_axes(datasets, rx_rank_map)
+    return merge_datasets(datasets, row_axes=row_axes, col_axes=col_axes)
+
+
+def _apply_v3_compat(
+    dataset: Dataset | MacroDataset,
+    rx_rank_map: dict[int, int],
+) -> Dataset | MacroDataset:
+    """Return a loader-level v3 compatibility view with RX grids merged per TX."""
+    if isinstance(dataset, Dataset):
+        return _merge_rx_grids_v3([dataset], rx_rank_map)
+    if len(dataset) <= 1:
+        return _merge_rx_grids_v3(dataset.datasets, rx_rank_map)
+
+    grouped: dict[tuple[int, int], list[Dataset]] = {}
+    ordered_tx_keys: list[tuple[int, int]] = []
+    for child in dataset.datasets:
+        txrx = child.get("txrx", {})
+        tx_key = (int(txrx.get("tx_set_id", -1)), int(txrx.get("tx_idx", -1)))
+        if tx_key not in grouped:
+            grouped[tx_key] = []
+            ordered_tx_keys.append(tx_key)
+        grouped[tx_key].append(child)
+
+    merged = [_merge_rx_grids_v3(grouped[tx_key], rx_rank_map) for tx_key in ordered_tx_keys]
+    return merged[0] if len(merged) == 1 else MacroDataset(merged)

--- a/deepmimo/datasets/dataset.py
+++ b/deepmimo/datasets/dataset.py
@@ -81,8 +81,6 @@ SHARED_PARAMS = [
     c.RT_PARAMS_PARAM_NAME,
 ]
 
-LEGACY_V3_INDEXING_SCENARIO_PREFIXES = ("boston", "o1_3p4", "o1_3p5")
-
 
 class Dataset(DotDict):
     """Class for managing DeepMIMO datasets.
@@ -974,69 +972,6 @@ class Dataset(DotDict):
         """
         return get_grid_idxs(self.grid_size, "col", col_idxs)
 
-    def _uses_legacy_v3_indexing(self) -> bool:
-        """Return whether this dataset belongs to a known legacy v3 scenario."""
-        scenario_name = str(self.get("parent_name", self.get("name", ""))).lower()
-        return any(
-            scenario_name.startswith(prefix) for prefix in LEGACY_V3_INDEXING_SCENARIO_PREFIXES
-        )
-
-    def _get_rx_rank_map(self) -> dict[int, int]:
-        """Map RX set ids to their scenario-order rank using numeric sorting."""
-        txrx_sets = self._data.get("txrx_sets")
-        if txrx_sets is None:
-            with contextlib.suppress(AttributeError, KeyError, OSError, ValueError):
-                txrx_sets = self.txrx_sets
-        if txrx_sets is None:
-            return {}
-
-        values = txrx_sets.values() if hasattr(txrx_sets, "values") else txrx_sets
-        rx_set_ids = []
-        for txrx_set in values:
-            if hasattr(txrx_set, "get"):
-                is_rx = txrx_set.get("is_rx", False)
-                rx_set_id = txrx_set.get("id")
-            else:
-                is_rx = txrx_set.is_rx
-                rx_set_id = txrx_set.id
-            if not is_rx:
-                continue
-            rx_set_ids.append(int(rx_set_id))
-
-        rx_set_ids.sort()
-        return {rx_set_id: rank for rank, rx_set_id in enumerate(rx_set_ids)}
-
-    def _get_legacy_v3_idxs(
-        self,
-        *,
-        row_idxs: int | list[int] | np.ndarray | None = None,
-        col_idxs: int | list[int] | np.ndarray | None = None,
-    ) -> np.ndarray:
-        """Return row/col indices following the legacy v3 convention."""
-        if not self._uses_legacy_v3_indexing():
-            msg = (
-                "`legacy_v3` indexing is only supported for known legacy scenarios "
-                "(for example Boston and O1 legacy releases)."
-            )
-            raise ValueError(msg)
-
-        if (row_idxs is None) == (col_idxs is None):
-            msg = "`legacy_v3` mode requires exactly one of row_idxs or col_idxs."
-            raise ValueError(msg)
-
-        txrx = self.get("txrx")
-        if txrx is None or "rx_set_id" not in txrx:
-            msg = "`legacy_v3` mode requires dataset TX/RX metadata."
-            raise ValueError(msg)
-
-        rx_rank = self._get_rx_rank_map().get(int(txrx["rx_set_id"]), 0)
-        if row_idxs is not None:
-            axis = "row" if rx_rank == 0 else "col"
-            return get_grid_idxs(self.grid_size, axis, row_idxs)
-
-        axis = "col" if rx_rank == 0 else "row"
-        return get_grid_idxs(self.grid_size, axis, col_idxs)
-
     def get_idxs(self, mode: str, **kwargs: Any) -> np.ndarray:
         """Unified dispatcher for user index selection.
 
@@ -1046,7 +981,6 @@ class Dataset(DotDict):
             - 'uniform': grid sampling: requires steps=[x_step, y_step]
             - 'row': row selection: requires row_idxs
             - 'col': column selection: requires col_idxs
-            - 'legacy_v3': legacy row/column compatibility on known v3 scenarios
             - 'limits': position bounds: requires x_min, x_max, y_min, y_max, z_min, z_max
             - 'id': user IDs selection: requires user_ids
 
@@ -1072,11 +1006,6 @@ class Dataset(DotDict):
                 result = self._get_row_idxs(kwargs[key])
             else:
                 result = self._get_col_idxs(kwargs[key])
-        elif m == "legacy_v3":
-            result = self._get_legacy_v3_idxs(
-                row_idxs=kwargs.get("row_idxs"),
-                col_idxs=kwargs.get("col_idxs"),
-            )
         elif m == "limits":
             result = get_idxs_with_limits(self.rx_pos, **kwargs)
         else:
@@ -1896,8 +1825,16 @@ class MergedGridDataset(Dataset):
 
         if axis == "row":
             grid_offsets = np.asarray(self._merge_spec["row_offsets"], dtype=int)
+            grid_axes = self._merge_spec.get(
+                "row_axes",
+                ["row"] * len(self._merge_spec["grid_sizes"]),
+            )
         elif axis == "col":
             grid_offsets = np.asarray(self._merge_spec["col_offsets"], dtype=int)
+            grid_axes = self._merge_spec.get(
+                "col_axes",
+                ["col"] * len(self._merge_spec["grid_sizes"]),
+            )
         else:
             msg = f"Invalid axis '{axis}', must be 'row' or 'col'"
             raise ValueError(msg)
@@ -1916,7 +1853,8 @@ class MergedGridDataset(Dataset):
         all_ue_idxs = []
         for idx, grid_idx in zip(idxs_arr, grid_idxs, strict=False):
             local_idx = int(idx - grid_offsets[grid_idx])
-            local_ue_idxs = get_grid_idxs(grid_sizes[grid_idx], axis, np.array([local_idx]))
+            local_axis = grid_axes[grid_idx]
+            local_ue_idxs = get_grid_idxs(grid_sizes[grid_idx], local_axis, np.array([local_idx]))
             all_ue_idxs.append(local_ue_idxs + ue_offsets[grid_idx])
 
         return np.concatenate(all_ue_idxs).astype(int)
@@ -1970,27 +1908,109 @@ def _missing_user_array(n_ue: int, tail_shape: tuple[int, ...], dtype: np.dtype)
     return np.full((n_ue, *tail_shape), fill_value, dtype=array_dtype)
 
 
-def _merged_grid_spec(datasets: list[Dataset]) -> dict[str, Any]:
+def _rx_rank_map(txrx_sets: list[Any] | dict[str, Any]) -> dict[int, int]:
+    """Map RX set IDs to their scenario order rank using numeric sorting."""
+    values = txrx_sets.values() if hasattr(txrx_sets, "values") else txrx_sets
+    rx_set_ids = []
+    for txrx_set in values:
+        if hasattr(txrx_set, "get"):
+            is_rx = txrx_set.get("is_rx", False)
+            rx_set_id = txrx_set.get("id")
+        else:
+            is_rx = txrx_set.is_rx
+            rx_set_id = txrx_set.id
+        if not is_rx:
+            continue
+        rx_set_ids.append(int(rx_set_id))
+
+    rx_set_ids.sort()
+    return {rx_set_id: rank for rank, rx_set_id in enumerate(rx_set_ids)}
+
+
+def _resolve_rx_rank_map(
+    datasets: list[Dataset],
+    *,
+    rx_rank_map: dict[int, int] | None = None,
+    txrx_sets: list[Any] | dict[str, Any] | None = None,
+) -> dict[int, int]:
+    """Resolve RX rank metadata from explicit input, scenario metadata, or dataset contents."""
+    if rx_rank_map is not None:
+        return rx_rank_map
+    if txrx_sets is not None:
+        return _rx_rank_map(txrx_sets)
+    if datasets:
+        with contextlib.suppress(AttributeError, KeyError, OSError, ValueError):
+            return _rx_rank_map(datasets[0].txrx_sets)
+
+    rx_set_ids = sorted(
+        {
+            int(dataset.get("txrx", {}).get("rx_set_id", -1))
+            for dataset in datasets
+            if dataset.hasattr("txrx")
+        }
+    )
+    return {rx_set_id: rank for rank, rx_set_id in enumerate(rx_set_ids)}
+
+
+def _merged_grid_spec(
+    datasets: list[Dataset],
+    *,
+    indexing: str = "native",
+    rx_rank_map: dict[int, int] | None = None,
+) -> dict[str, Any]:
     """Build global row/col indexing metadata for merged multi-grid datasets."""
     grid_sizes = [np.asarray(ds.grid_size, dtype=int) for ds in datasets]
     ue_offsets = np.cumsum([0, *[int(ds.n_ue) for ds in datasets[:-1]]], dtype=int)
-    n_rows_per_grid = [int(grid_size[1]) for grid_size in grid_sizes]
-    n_cols_per_grid = [int(grid_size[0]) for grid_size in grid_sizes]
+    rx_set_ids = [int(ds.get("txrx", {}).get("rx_set_id", -1)) for ds in datasets]
+
+    if indexing == "native":
+        row_axes = ["row"] * len(datasets)
+        col_axes = ["col"] * len(datasets)
+    elif indexing == "v3":
+        resolved_rx_rank_map = rx_rank_map or {}
+        row_axes = [
+            "row" if resolved_rx_rank_map.get(rx_set_id, 0) == 0 else "col"
+            for rx_set_id in rx_set_ids
+        ]
+        col_axes = [
+            "col" if resolved_rx_rank_map.get(rx_set_id, 0) == 0 else "row"
+            for rx_set_id in rx_set_ids
+        ]
+    else:
+        msg = f"Unknown indexing mode '{indexing}'. Expected 'native' or 'v3'."
+        raise ValueError(msg)
+
+    n_rows_per_grid = [
+        int(grid_size[1]) if row_axis == "row" else int(grid_size[0])
+        for grid_size, row_axis in zip(grid_sizes, row_axes, strict=False)
+    ]
+    n_cols_per_grid = [
+        int(grid_size[0]) if col_axis == "col" else int(grid_size[1])
+        for grid_size, col_axis in zip(grid_sizes, col_axes, strict=False)
+    ]
     return {
         "ue_offsets": ue_offsets,
         "grid_sizes": grid_sizes,
+        "row_axes": row_axes,
+        "col_axes": col_axes,
         "row_offsets": np.cumsum([0, *n_rows_per_grid], dtype=int),
         "col_offsets": np.cumsum([0, *n_cols_per_grid], dtype=int),
     }
 
 
-def merge_datasets(datasets: list[Dataset]) -> Dataset:  # noqa: C901, PLR0912
+def merge_datasets(  # noqa: C901, PLR0912
+    datasets: list[Dataset],
+    *,
+    indexing: str = "native",
+    rx_rank_map: dict[int, int] | None = None,
+    txrx_sets: list[Any] | dict[str, Any] | None = None,
+) -> Dataset:
     """Merge datasets that share one transmitter into an explicit merged-grid dataset."""
     if not datasets:
         msg = "Cannot merge an empty dataset list"
         raise ValueError(msg)
 
-    if len(datasets) == 1:
+    if len(datasets) == 1 and indexing == "native":
         return datasets[0]
 
     tx_keys = {
@@ -2077,7 +2097,19 @@ def merge_datasets(datasets: list[Dataset]) -> Dataset:  # noqa: C901, PLR0912
     if datasets[0].hasattr("txrx"):
         merged_data["txrx"] = dict(datasets[0].txrx)
 
-    return MergedGridDataset(merged_data, merge_spec=_merged_grid_spec(datasets))
+    resolved_rx_rank_map = _resolve_rx_rank_map(
+        datasets,
+        rx_rank_map=rx_rank_map,
+        txrx_sets=txrx_sets,
+    )
+    return MergedGridDataset(
+        merged_data,
+        merge_spec=_merged_grid_spec(
+            datasets,
+            indexing=indexing,
+            rx_rank_map=resolved_rx_rank_map,
+        ),
+    )
 
 
 class MacroDataset:

--- a/deepmimo/datasets/dataset.py
+++ b/deepmimo/datasets/dataset.py
@@ -81,6 +81,8 @@ SHARED_PARAMS = [
     c.RT_PARAMS_PARAM_NAME,
 ]
 
+LEGACY_V3_INDEXING_SCENARIO_PREFIXES = ("boston", "o1_3p4", "o1_3p5")
+
 
 class Dataset(DotDict):
     """Class for managing DeepMIMO datasets.
@@ -972,6 +974,69 @@ class Dataset(DotDict):
         """
         return get_grid_idxs(self.grid_size, "col", col_idxs)
 
+    def _uses_legacy_v3_indexing(self) -> bool:
+        """Return whether this dataset belongs to a known legacy v3 scenario."""
+        scenario_name = str(self.get("parent_name", self.get("name", ""))).lower()
+        return any(
+            scenario_name.startswith(prefix) for prefix in LEGACY_V3_INDEXING_SCENARIO_PREFIXES
+        )
+
+    def _get_rx_rank_map(self) -> dict[int, int]:
+        """Map RX set ids to their scenario-order rank using numeric sorting."""
+        txrx_sets = self._data.get("txrx_sets")
+        if txrx_sets is None:
+            with contextlib.suppress(AttributeError, KeyError, OSError, ValueError):
+                txrx_sets = self.txrx_sets
+        if txrx_sets is None:
+            return {}
+
+        values = txrx_sets.values() if hasattr(txrx_sets, "values") else txrx_sets
+        rx_set_ids = []
+        for txrx_set in values:
+            if hasattr(txrx_set, "get"):
+                is_rx = txrx_set.get("is_rx", False)
+                rx_set_id = txrx_set.get("id")
+            else:
+                is_rx = txrx_set.is_rx
+                rx_set_id = txrx_set.id
+            if not is_rx:
+                continue
+            rx_set_ids.append(int(rx_set_id))
+
+        rx_set_ids.sort()
+        return {rx_set_id: rank for rank, rx_set_id in enumerate(rx_set_ids)}
+
+    def _get_legacy_v3_idxs(
+        self,
+        *,
+        row_idxs: int | list[int] | np.ndarray | None = None,
+        col_idxs: int | list[int] | np.ndarray | None = None,
+    ) -> np.ndarray:
+        """Return row/col indices following the legacy v3 convention."""
+        if not self._uses_legacy_v3_indexing():
+            msg = (
+                "`legacy_v3` indexing is only supported for known legacy scenarios "
+                "(for example Boston and O1 legacy releases)."
+            )
+            raise ValueError(msg)
+
+        if (row_idxs is None) == (col_idxs is None):
+            msg = "`legacy_v3` mode requires exactly one of row_idxs or col_idxs."
+            raise ValueError(msg)
+
+        txrx = self.get("txrx")
+        if txrx is None or "rx_set_id" not in txrx:
+            msg = "`legacy_v3` mode requires dataset TX/RX metadata."
+            raise ValueError(msg)
+
+        rx_rank = self._get_rx_rank_map().get(int(txrx["rx_set_id"]), 0)
+        if row_idxs is not None:
+            axis = "row" if rx_rank == 0 else "col"
+            return get_grid_idxs(self.grid_size, axis, row_idxs)
+
+        axis = "col" if rx_rank == 0 else "row"
+        return get_grid_idxs(self.grid_size, axis, col_idxs)
+
     def get_idxs(self, mode: str, **kwargs: Any) -> np.ndarray:
         """Unified dispatcher for user index selection.
 
@@ -981,6 +1046,7 @@ class Dataset(DotDict):
             - 'uniform': grid sampling: requires steps=[x_step, y_step]
             - 'row': row selection: requires row_idxs
             - 'col': column selection: requires col_idxs
+            - 'legacy_v3': legacy row/column compatibility on known v3 scenarios
             - 'limits': position bounds: requires x_min, x_max, y_min, y_max, z_min, z_max
             - 'id': user IDs selection: requires user_ids
 
@@ -990,24 +1056,33 @@ class Dataset(DotDict):
         """
         m = mode.lower()
         if m == "active":
-            return self._get_active_idxs()
-        if m == "linear":
-            return self._get_linear_idxs(
+            result = self._get_active_idxs()
+        elif m == "linear":
+            result = self._get_linear_idxs(
                 kwargs["start_pos"],
                 kwargs["end_pos"],
                 kwargs["n_steps"],
                 filter_repeated=kwargs.get("filter_repeated", True),
             )
-        if m == "uniform":
-            return self._get_uniform_idxs(kwargs["steps"])
-        if m == "row":
-            return self._get_row_idxs(kwargs["row_idxs"])
-        if m == "col":
-            return self._get_col_idxs(kwargs["col_idxs"])
-        if m == "limits":
-            return get_idxs_with_limits(self.rx_pos, **kwargs)
-        msg = f"Unknown mode: {mode}"
-        raise ValueError(msg)
+        elif m == "uniform":
+            result = self._get_uniform_idxs(kwargs["steps"])
+        elif m in {"row", "col"}:
+            key = "row_idxs" if m == "row" else "col_idxs"
+            if m == "row":
+                result = self._get_row_idxs(kwargs[key])
+            else:
+                result = self._get_col_idxs(kwargs[key])
+        elif m == "legacy_v3":
+            result = self._get_legacy_v3_idxs(
+                row_idxs=kwargs.get("row_idxs"),
+                col_idxs=kwargs.get("col_idxs"),
+            )
+        elif m == "limits":
+            result = get_idxs_with_limits(self.rx_pos, **kwargs)
+        else:
+            msg = f"Unknown mode: {mode}"
+            raise ValueError(msg)
+        return result
 
     def _trim_by_path(self, path_mask: np.ndarray) -> Dataset:
         """Trim paths based on a boolean mask.

--- a/deepmimo/datasets/dataset.py
+++ b/deepmimo/datasets/dataset.py
@@ -1000,12 +1000,10 @@ class Dataset(DotDict):
             )
         elif m == "uniform":
             result = self._get_uniform_idxs(kwargs["steps"])
-        elif m in {"row", "col"}:
-            key = "row_idxs" if m == "row" else "col_idxs"
-            if m == "row":
-                result = self._get_row_idxs(kwargs[key])
-            else:
-                result = self._get_col_idxs(kwargs[key])
+        elif m == "row":
+            result = self._get_row_idxs(kwargs["row_idxs"])
+        elif m == "col":
+            result = self._get_col_idxs(kwargs["col_idxs"])
         elif m == "limits":
             result = get_idxs_with_limits(self.rx_pos, **kwargs)
         else:
@@ -1941,15 +1939,7 @@ def _resolve_rx_rank_map(
     if datasets:
         with contextlib.suppress(AttributeError, KeyError, OSError, ValueError):
             return _rx_rank_map(datasets[0].txrx_sets)
-
-    rx_set_ids = sorted(
-        {
-            int(dataset.get("txrx", {}).get("rx_set_id", -1))
-            for dataset in datasets
-            if dataset.hasattr("txrx")
-        }
-    )
-    return {rx_set_id: rank for rank, rx_set_id in enumerate(rx_set_ids)}
+    return {}
 
 
 def _merged_grid_spec(
@@ -1998,7 +1988,7 @@ def _merged_grid_spec(
     }
 
 
-def merge_datasets(  # noqa: C901, PLR0912
+def merge_datasets(  # noqa: C901, PLR0912, PLR0915
     datasets: list[Dataset],
     *,
     indexing: str = "native",
@@ -2102,6 +2092,12 @@ def merge_datasets(  # noqa: C901, PLR0912
         rx_rank_map=rx_rank_map,
         txrx_sets=txrx_sets,
     )
+    if indexing == "v3" and not resolved_rx_rank_map:
+        msg = (
+            "V3 merged indexing requires RX rank metadata. Pass `rx_rank_map` or "
+            "`txrx_sets`, or load the dataset through `dm.load(..., compat_v3=True)`."
+        )
+        raise ValueError(msg)
     return MergedGridDataset(
         merged_data,
         merge_spec=_merged_grid_spec(

--- a/deepmimo/datasets/dataset.py
+++ b/deepmimo/datasets/dataset.py
@@ -1906,101 +1906,51 @@ def _missing_user_array(n_ue: int, tail_shape: tuple[int, ...], dtype: np.dtype)
     return np.full((n_ue, *tail_shape), fill_value, dtype=array_dtype)
 
 
-def _rx_rank_map(txrx_sets: list[Any] | dict[str, Any]) -> dict[int, int]:
-    """Map RX set IDs to their scenario order rank using numeric sorting."""
-    values = txrx_sets.values() if hasattr(txrx_sets, "values") else txrx_sets
-    rx_set_ids = []
-    for txrx_set in values:
-        if hasattr(txrx_set, "get"):
-            is_rx = txrx_set.get("is_rx", False)
-            rx_set_id = txrx_set.get("id")
-        else:
-            is_rx = txrx_set.is_rx
-            rx_set_id = txrx_set.id
-        if not is_rx:
-            continue
-        rx_set_ids.append(int(rx_set_id))
-
-    rx_set_ids.sort()
-    return {rx_set_id: rank for rank, rx_set_id in enumerate(rx_set_ids)}
-
-
-def _resolve_rx_rank_map(
-    datasets: list[Dataset],
-    *,
-    rx_rank_map: dict[int, int] | None = None,
-    txrx_sets: list[Any] | dict[str, Any] | None = None,
-) -> dict[int, int]:
-    """Resolve RX rank metadata from explicit input, scenario metadata, or dataset contents."""
-    if rx_rank_map is not None:
-        return rx_rank_map
-    if txrx_sets is not None:
-        return _rx_rank_map(txrx_sets)
-    if datasets:
-        with contextlib.suppress(AttributeError, KeyError, OSError, ValueError):
-            return _rx_rank_map(datasets[0].txrx_sets)
-    return {}
-
-
 def _merged_grid_spec(
     datasets: list[Dataset],
     *,
-    indexing: str = "native",
-    rx_rank_map: dict[int, int] | None = None,
+    row_axes: list[str] | None = None,
+    col_axes: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build global row/col indexing metadata for merged multi-grid datasets."""
     grid_sizes = [np.asarray(ds.grid_size, dtype=int) for ds in datasets]
     ue_offsets = np.cumsum([0, *[int(ds.n_ue) for ds in datasets[:-1]]], dtype=int)
-    rx_set_ids = [int(ds.get("txrx", {}).get("rx_set_id", -1)) for ds in datasets]
-
-    if indexing == "native":
-        row_axes = ["row"] * len(datasets)
-        col_axes = ["col"] * len(datasets)
-    elif indexing == "v3":
-        resolved_rx_rank_map = rx_rank_map or {}
-        row_axes = [
-            "row" if resolved_rx_rank_map.get(rx_set_id, 0) == 0 else "col"
-            for rx_set_id in rx_set_ids
-        ]
-        col_axes = [
-            "col" if resolved_rx_rank_map.get(rx_set_id, 0) == 0 else "row"
-            for rx_set_id in rx_set_ids
-        ]
-    else:
-        msg = f"Unknown indexing mode '{indexing}'. Expected 'native' or 'v3'."
+    resolved_row_axes = ["row"] * len(datasets) if row_axes is None else list(row_axes)
+    resolved_col_axes = ["col"] * len(datasets) if col_axes is None else list(col_axes)
+    if len(resolved_row_axes) != len(datasets) or len(resolved_col_axes) != len(datasets):
+        msg = "Merged-grid axis overrides must match the number of datasets."
         raise ValueError(msg)
 
     n_rows_per_grid = [
         int(grid_size[1]) if row_axis == "row" else int(grid_size[0])
-        for grid_size, row_axis in zip(grid_sizes, row_axes, strict=False)
+        for grid_size, row_axis in zip(grid_sizes, resolved_row_axes, strict=False)
     ]
     n_cols_per_grid = [
         int(grid_size[0]) if col_axis == "col" else int(grid_size[1])
-        for grid_size, col_axis in zip(grid_sizes, col_axes, strict=False)
+        for grid_size, col_axis in zip(grid_sizes, resolved_col_axes, strict=False)
     ]
     return {
         "ue_offsets": ue_offsets,
         "grid_sizes": grid_sizes,
-        "row_axes": row_axes,
-        "col_axes": col_axes,
+        "row_axes": resolved_row_axes,
+        "col_axes": resolved_col_axes,
         "row_offsets": np.cumsum([0, *n_rows_per_grid], dtype=int),
         "col_offsets": np.cumsum([0, *n_cols_per_grid], dtype=int),
     }
 
 
-def merge_datasets(  # noqa: C901, PLR0912, PLR0915
+def merge_datasets(  # noqa: C901, PLR0912
     datasets: list[Dataset],
     *,
-    indexing: str = "native",
-    rx_rank_map: dict[int, int] | None = None,
-    txrx_sets: list[Any] | dict[str, Any] | None = None,
+    row_axes: list[str] | None = None,
+    col_axes: list[str] | None = None,
 ) -> Dataset:
     """Merge datasets that share one transmitter into an explicit merged-grid dataset."""
     if not datasets:
         msg = "Cannot merge an empty dataset list"
         raise ValueError(msg)
 
-    if len(datasets) == 1 and indexing == "native":
+    if len(datasets) == 1 and row_axes is None and col_axes is None:
         return datasets[0]
 
     tx_keys = {
@@ -2087,23 +2037,12 @@ def merge_datasets(  # noqa: C901, PLR0912, PLR0915
     if datasets[0].hasattr("txrx"):
         merged_data["txrx"] = dict(datasets[0].txrx)
 
-    resolved_rx_rank_map = _resolve_rx_rank_map(
-        datasets,
-        rx_rank_map=rx_rank_map,
-        txrx_sets=txrx_sets,
-    )
-    if indexing == "v3" and not resolved_rx_rank_map:
-        msg = (
-            "V3 merged indexing requires RX rank metadata. Pass `rx_rank_map` or "
-            "`txrx_sets`, or load the dataset through `dm.load(..., compat_v3=True)`."
-        )
-        raise ValueError(msg)
     return MergedGridDataset(
         merged_data,
         merge_spec=_merged_grid_spec(
             datasets,
-            indexing=indexing,
-            rx_rank_map=resolved_rx_rank_map,
+            row_axes=row_axes,
+            col_axes=col_axes,
         ),
     )
 

--- a/deepmimo/datasets/load.py
+++ b/deepmimo/datasets/load.py
@@ -127,6 +127,7 @@ def load(
     )
     return dataset
 
+
 def _load_dataset(folder: str, params: dict, load_params: dict) -> Dataset | MacroDataset:
     """Load a single dataset from a scenario folder.
 

--- a/deepmimo/datasets/load.py
+++ b/deepmimo/datasets/load.py
@@ -19,7 +19,8 @@ import numpy as np
 from deepmimo import consts as c
 from deepmimo.core.materials import MaterialList
 from deepmimo.core.scene import Scene
-from deepmimo.datasets.dataset import Dataset, DynamicDataset, MacroDataset, merge_datasets
+from deepmimo.datasets.compat_v3 import _apply_v3_compat, _rx_rank_map
+from deepmimo.datasets.dataset import Dataset, DynamicDataset, MacroDataset
 from deepmimo.utils import (
     DotDict,
     get_mat_filename,
@@ -43,7 +44,7 @@ def load(
     Args:
         scen_name (str): Name of the scenario to load
         compat_v3 (bool): If True, merge RX grids per TX and expose v3-style
-            global row/column indexing semantics.
+            global row/column indexing semantics for static scenarios.
         **load_params: Additional parameters for loading the scenario. Can be passed as a dictionary
             or as keyword arguments. Available parameters are:
 
@@ -64,8 +65,8 @@ def load(
                 - str: 'all' to load all available matrices
 
             * compat_v3 (bool, optional): If True, merge RX grids per TX and
-                expose v3-style global row/column indexing semantics. Defaults
-                to False.
+                expose v3-style global row/column indexing semantics for static
+                scenarios. Defaults to False.
 
     Returns:
         Dataset or MacroDataset: Loaded dataset(s)
@@ -105,14 +106,16 @@ def load(
     # Load scenario data
     n_snapshots = params[c.SCENE_PARAM_NAME][c.SCENE_PARAM_NUMBER_SCENES]
     if n_snapshots > 1:  # dynamic (multiple scenes)
+        if compat_v3:
+            msg = "`compat_v3=True` is only supported for static scenarios."
+            raise ValueError(msg)
         dataset_list = []
         scen_folder_path = Path(scen_folder)
         scene_folders = sorted([d.name for d in scen_folder_path.iterdir() if d.is_dir()])
         for snapshot_i in range(n_snapshots):
             snapshot_folder = str(scen_folder_path / scene_folders[snapshot_i])
             print(f"Scene {snapshot_i + 1}/{n_snapshots}")
-            snapshot = _load_dataset(snapshot_folder, params, load_params)
-            dataset_list += [_apply_v3_compat(snapshot, rx_rank_map) if compat_v3 else snapshot]
+            dataset_list += [_load_dataset(snapshot_folder, params, load_params)]
         dataset = DynamicDataset(dataset_list, scen_name)
     else:  # static (single scene)
         dataset = _load_dataset(scen_folder, params, load_params)
@@ -123,41 +126,6 @@ def load(
         {**dataset[c.LOAD_PARAMS_PARAM_NAME], "compat_v3": compat_v3},
     )
     return dataset
-
-
-def _rx_rank_map(txrx_dict: dict[str, Any]) -> dict[int, int]:
-    """Map RX set IDs to their scenario order rank using numeric sorting."""
-    rx_sets = [txrx_dict[key] for key in sorted(txrx_dict.keys()) if txrx_dict[key]["is_rx"]]
-    rx_set_ids = sorted(int(rx_set["id"]) for rx_set in rx_sets)
-    return {rx_set_id: rank for rank, rx_set_id in enumerate(rx_set_ids)}
-
-
-def _apply_v3_compat(
-    dataset: Dataset | MacroDataset,
-    rx_rank_map: dict[int, int],
-) -> Dataset | MacroDataset:
-    """Return a loader-level v3 compatibility view with RX grids merged per TX."""
-    if isinstance(dataset, Dataset):
-        return merge_datasets([dataset], indexing="v3", rx_rank_map=rx_rank_map)
-    if len(dataset) <= 1:
-        return merge_datasets(dataset.datasets, indexing="v3", rx_rank_map=rx_rank_map)
-
-    grouped: dict[tuple[int, int], list[Dataset]] = {}
-    ordered_tx_keys: list[tuple[int, int]] = []
-    for child in dataset.datasets:
-        txrx = child.get("txrx", {})
-        tx_key = (int(txrx.get("tx_set_id", -1)), int(txrx.get("tx_idx", -1)))
-        if tx_key not in grouped:
-            grouped[tx_key] = []
-            ordered_tx_keys.append(tx_key)
-        grouped[tx_key].append(child)
-
-    merged = [
-        merge_datasets(grouped[tx_key], indexing="v3", rx_rank_map=rx_rank_map)
-        for tx_key in ordered_tx_keys
-    ]
-    return merged[0] if len(merged) == 1 else MacroDataset(merged)
-
 
 def _load_dataset(folder: str, params: dict, load_params: dict) -> Dataset | MacroDataset:
     """Load a single dataset from a scenario folder.

--- a/deepmimo/datasets/load.py
+++ b/deepmimo/datasets/load.py
@@ -19,7 +19,7 @@ import numpy as np
 from deepmimo import consts as c
 from deepmimo.core.materials import MaterialList
 from deepmimo.core.scene import Scene
-from deepmimo.datasets.dataset import Dataset, DynamicDataset, MacroDataset
+from deepmimo.datasets.dataset import Dataset, DynamicDataset, MacroDataset, merge_datasets
 from deepmimo.utils import (
     DotDict,
     get_mat_filename,
@@ -30,13 +30,20 @@ from deepmimo.utils import (
 )
 
 
-def load(scen_name: str, **load_params: Any) -> Dataset | MacroDataset:
+def load(
+    scen_name: str,
+    *,
+    compat_v3: bool = False,
+    **load_params: Any,
+) -> Dataset | MacroDataset:
     """Load a DeepMIMO scenario.
 
     This function loads raytracing data and creates a Dataset or MacroDataset instance.
 
     Args:
         scen_name (str): Name of the scenario to load
+        compat_v3 (bool): If True, merge RX grids per TX and expose v3-style
+            global row/column indexing semantics.
         **load_params: Additional parameters for loading the scenario. Can be passed as a dictionary
             or as keyword arguments. Available parameters are:
 
@@ -55,6 +62,10 @@ def load(scen_name: str, **load_params: Any) -> Dataset | MacroDataset:
                 Defaults to 'all'. Can be:
                 - list: List of matrix names to load
                 - str: 'all' to load all available matrices
+
+            * compat_v3 (bool, optional): If True, merge RX grids per TX and
+                expose v3-style global row/column indexing semantics. Defaults
+                to False.
 
     Returns:
         Dataset or MacroDataset: Loaded dataset(s)
@@ -89,6 +100,7 @@ def load(scen_name: str, **load_params: Any) -> Dataset | MacroDataset:
     # Load parameters file
     params_file = get_params_path(scen_name)
     params = load_dict_from_json(params_file)
+    rx_rank_map = _rx_rank_map(params[c.TXRX_PARAM_NAME])
 
     # Load scenario data
     n_snapshots = params[c.SCENE_PARAM_NAME][c.SCENE_PARAM_NUMBER_SCENES]
@@ -99,11 +111,52 @@ def load(scen_name: str, **load_params: Any) -> Dataset | MacroDataset:
         for snapshot_i in range(n_snapshots):
             snapshot_folder = str(scen_folder_path / scene_folders[snapshot_i])
             print(f"Scene {snapshot_i + 1}/{n_snapshots}")
-            dataset_list += [_load_dataset(snapshot_folder, params, load_params)]
+            snapshot = _load_dataset(snapshot_folder, params, load_params)
+            dataset_list += [_apply_v3_compat(snapshot, rx_rank_map) if compat_v3 else snapshot]
         dataset = DynamicDataset(dataset_list, scen_name)
     else:  # static (single scene)
         dataset = _load_dataset(scen_folder, params, load_params)
+        if compat_v3:
+            dataset = _apply_v3_compat(dataset, rx_rank_map)
+
+    dataset[c.LOAD_PARAMS_PARAM_NAME] = DotDict(
+        {**dataset[c.LOAD_PARAMS_PARAM_NAME], "compat_v3": compat_v3},
+    )
     return dataset
+
+
+def _rx_rank_map(txrx_dict: dict[str, Any]) -> dict[int, int]:
+    """Map RX set IDs to their scenario order rank using numeric sorting."""
+    rx_sets = [txrx_dict[key] for key in sorted(txrx_dict.keys()) if txrx_dict[key]["is_rx"]]
+    rx_set_ids = sorted(int(rx_set["id"]) for rx_set in rx_sets)
+    return {rx_set_id: rank for rank, rx_set_id in enumerate(rx_set_ids)}
+
+
+def _apply_v3_compat(
+    dataset: Dataset | MacroDataset,
+    rx_rank_map: dict[int, int],
+) -> Dataset | MacroDataset:
+    """Return a loader-level v3 compatibility view with RX grids merged per TX."""
+    if isinstance(dataset, Dataset):
+        return merge_datasets([dataset], indexing="v3", rx_rank_map=rx_rank_map)
+    if len(dataset) <= 1:
+        return merge_datasets(dataset.datasets, indexing="v3", rx_rank_map=rx_rank_map)
+
+    grouped: dict[tuple[int, int], list[Dataset]] = {}
+    ordered_tx_keys: list[tuple[int, int]] = []
+    for child in dataset.datasets:
+        txrx = child.get("txrx", {})
+        tx_key = (int(txrx.get("tx_set_id", -1)), int(txrx.get("tx_idx", -1)))
+        if tx_key not in grouped:
+            grouped[tx_key] = []
+            ordered_tx_keys.append(tx_key)
+        grouped[tx_key].append(child)
+
+    merged = [
+        merge_datasets(grouped[tx_key], indexing="v3", rx_rank_map=rx_rank_map)
+        for tx_key in ordered_tx_keys
+    ]
+    return merged[0] if len(merged) == 1 else MacroDataset(merged)
 
 
 def _load_dataset(folder: str, params: dict, load_params: dict) -> Dataset | MacroDataset:

--- a/docs/tutorials/8_migration_guide.py
+++ b/docs/tutorials/8_migration_guide.py
@@ -13,6 +13,7 @@
 # - Channel generation changes
 # - Data access and format changes
 # - User selection changes
+# - Legacy v3 row/column compatibility
 # - Best practices for migration
 #
 # **Related Video:** [Migration Video](https://youtu.be/15nQWS15h3k)
@@ -224,6 +225,29 @@ print("v4 user selection (post-loading):")
 print(f"  Selected {len(row_idxs)} users")
 
 # %% [markdown]
+# ### Matching Legacy v3 Row/Column Results
+#
+# DeepMIMO v4 keeps the native grid geometry of the scenario. For a small set of
+# legacy multi-grid scenarios, DeepMIMO v3 interpreted row/column indexing
+# differently on non-primary RX grids. If you need to reproduce those exact v3
+# row/column selections during migration, use `legacy_v3` explicitly.
+
+# %%
+legacy_v3_selection = """
+# Only for known legacy scenarios when reproducing old v3 row/column results
+dataset = dm.load("o1_3p4", tx_sets=[3], rx_sets=[1])
+
+# Match the old v3 interpretation of rows/columns on this RX grid
+legacy_rows = dataset.get_idxs("legacy_v3", row_idxs=[0, 10, 20])
+legacy_cols = dataset.get_idxs("legacy_v3", col_idxs=[0, 5, 10])
+
+subset = dataset.trim(idxs=legacy_rows)
+"""
+
+print("v4 legacy v3 compatibility (migration-only):")
+print(legacy_v3_selection)
+
+# %% [markdown]
 # ## Parameter Names
 #
 # Many parameter names have changed.
@@ -265,6 +289,7 @@ print("  - Average size reduction: ~50%")
 # - [ ] Replace `generate_data()` with `dataset.compute_channels()`
 # - [ ] Update data access from `dataset[bs]["user"]["param"]` to `dataset.param`
 # - [ ] Move user selection from params to `dataset.get_idxs()` and `dataset.trim()`
+# - [ ] Use `get_idxs("legacy_v3", ...)` only when reproducing exact old v3 indexing
 # - [ ] Update parameter names (DoA/DoD -> aoa/aod, etc.)
 # - [ ] Update antenna configuration to ChannelParameters
 # - [ ] Test thoroughly with your existing workflows

--- a/docs/tutorials/8_migration_guide.py
+++ b/docs/tutorials/8_migration_guide.py
@@ -227,19 +227,20 @@ print(f"  Selected {len(row_idxs)} users")
 # %% [markdown]
 # ### Matching Legacy v3 Row/Column Results
 #
-# DeepMIMO v4 keeps the native grid geometry of the scenario. For a small set of
-# legacy multi-grid scenarios, DeepMIMO v3 interpreted row/column indexing
-# differently on non-primary RX grids. If you need to reproduce those exact v3
-# row/column selections during migration, use `legacy_v3` explicitly.
+# DeepMIMO v4 keeps the native grid geometry of the scenario. In DeepMIMO v3,
+# some multi-grid scenarios behaved like one merged RX grid per transmitter, and
+# row/column indexing could change direction on non-primary RX grids. If you
+# need to reproduce those exact v3 selections during migration, load the
+# scenario with `compat_v3=True`.
 
 # %%
 legacy_v3_selection = """
-# Only for known legacy scenarios when reproducing old v3 row/column results
-dataset = dm.load("o1_3p4", tx_sets=[3], rx_sets=[1])
+# Migration-only: reproduce the old v3 merged-grid indexing behavior
+dataset = dm.load("o1_3p4", tx_sets=[3], compat_v3=True)
 
-# Match the old v3 interpretation of rows/columns on this RX grid
-legacy_rows = dataset.get_idxs("legacy_v3", row_idxs=[0, 10, 20])
-legacy_cols = dataset.get_idxs("legacy_v3", col_idxs=[0, 5, 10])
+# `compat_v3=True` merges RX grids per TX and restores v3-style row/col indexing
+legacy_rows = dataset.get_idxs("row", row_idxs=[0, 10, 20])
+legacy_cols = dataset.get_idxs("col", col_idxs=[0, 5, 10])
 
 subset = dataset.trim(idxs=legacy_rows)
 """
@@ -289,7 +290,7 @@ print("  - Average size reduction: ~50%")
 # - [ ] Replace `generate_data()` with `dataset.compute_channels()`
 # - [ ] Update data access from `dataset[bs]["user"]["param"]` to `dataset.param`
 # - [ ] Move user selection from params to `dataset.get_idxs()` and `dataset.trim()`
-# - [ ] Use `get_idxs("legacy_v3", ...)` only when reproducing exact old v3 indexing
+# - [ ] Use `dm.load(..., compat_v3=True)` only when reproducing exact old v3 indexing
 # - [ ] Update parameter names (DoA/DoD -> aoa/aod, etc.)
 # - [ ] Update antenna configuration to ChannelParameters
 # - [ ] Test thoroughly with your existing workflows

--- a/docs/tutorials/8_migration_guide.py
+++ b/docs/tutorials/8_migration_guide.py
@@ -232,6 +232,16 @@ print(f"  Selected {len(row_idxs)} users")
 # row/column indexing could change direction on non-primary RX grids. If you
 # need to reproduce those exact v3 selections during migration, load the
 # scenario with `compat_v3=True`.
+#
+# When `compat_v3=True` in `dm.load(...)`, DeepMIMO applies the old merged-grid
+# indexing view:
+# - RX grids are merged per transmitter
+# - the primary RX grid (rank 0) keeps normal row/column behavior
+# - non-primary RX grids (rank >= 1) swap row/column semantics
+#
+# This is intended only for reproducing backward-compatible user selection
+# behavior during migration, including workflows where `rx_sets` is explicitly
+# provided for a non-primary grid.
 
 # %%
 legacy_v3_selection = """

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -4,7 +4,13 @@ import numpy as np
 import pytest
 
 from deepmimo import consts as c
-from deepmimo.datasets.dataset import Dataset, DynamicDataset, MacroDataset, MergedGridDataset
+from deepmimo.datasets.dataset import (
+    Dataset,
+    DynamicDataset,
+    MacroDataset,
+    MergedGridDataset,
+    merge_datasets,
+)
 from deepmimo.datasets.load import _apply_v3_compat, _validate_txrx_sets
 
 
@@ -399,6 +405,14 @@ def test_apply_v3_compat_returns_one_merged_dataset_per_transmitter() -> None:
     assert all(isinstance(child, MergedGridDataset) for child in compat.datasets)
     assert compat[0].n_ue == g1.n_ue + g2.n_ue
     assert compat[1].n_ue == g3.n_ue + g4.n_ue
+
+
+def test_merge_datasets_v3_requires_rx_rank_metadata() -> None:
+    """Direct v3 merged indexing should fail loudly when RX rank metadata is unavailable."""
+    dataset = _make_grid_dataset(nx=4, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=1)
+
+    with pytest.raises(ValueError, match="requires RX rank metadata"):
+        merge_datasets([dataset], indexing="v3")
 
 
 def test_validate_txrx_sets_orders_allowed_ids_deterministically() -> None:

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -4,14 +4,14 @@ import numpy as np
 import pytest
 
 from deepmimo import consts as c
+from deepmimo.datasets.compat_v3 import _apply_v3_compat, _merge_rx_grids_v3, _rx_rank_map
 from deepmimo.datasets.dataset import (
     Dataset,
     DynamicDataset,
     MacroDataset,
     MergedGridDataset,
-    merge_datasets,
 )
-from deepmimo.datasets.load import _apply_v3_compat, _validate_txrx_sets
+from deepmimo.datasets.load import _validate_txrx_sets
 
 
 @pytest.fixture
@@ -407,12 +407,24 @@ def test_apply_v3_compat_returns_one_merged_dataset_per_transmitter() -> None:
     assert compat[1].n_ue == g3.n_ue + g4.n_ue
 
 
-def test_merge_datasets_v3_requires_rx_rank_metadata() -> None:
-    """Direct v3 merged indexing should fail loudly when RX rank metadata is unavailable."""
+def test_merge_rx_grids_v3_requires_rx_rank_metadata() -> None:
+    """Direct v3 compatibility helpers should fail loudly without RX rank metadata."""
     dataset = _make_grid_dataset(nx=4, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=1)
 
     with pytest.raises(ValueError, match="requires RX rank metadata"):
-        merge_datasets([dataset], indexing="v3")
+        _merge_rx_grids_v3([dataset], rx_rank_map={})
+
+
+def test_rx_rank_map_uses_numeric_set_ids() -> None:
+    """RX rank mapping should sort by numeric RX set id, not key string."""
+    txrx_dict = {
+        "txrx_set_10": {"id": 10, "is_tx": False, "is_rx": True},
+        "txrx_set_2": {"id": 2, "is_tx": False, "is_rx": True},
+        "txrx_set_0": {"id": 0, "is_tx": False, "is_rx": True},
+        "txrx_set_3": {"id": 3, "is_tx": True, "is_rx": False},
+    }
+
+    assert _rx_rank_map(txrx_dict) == {0: 0, 2: 1, 10: 2}
 
 
 def test_validate_txrx_sets_orders_allowed_ids_deterministically() -> None:

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -283,6 +283,16 @@ def _make_macro_dataset(*datasets: Dataset) -> MacroDataset:
     return MacroDataset(list(datasets))
 
 
+def _make_txrx_sets_dict() -> dict[str, dict[str, int | bool]]:
+    """Create synthetic TX/RX set metadata with deterministic numeric ids."""
+    return {
+        "txrx_set_0": {"id": 0, "is_tx": False, "is_rx": True},
+        "txrx_set_1": {"id": 1, "is_tx": False, "is_rx": True},
+        "txrx_set_2": {"id": 2, "is_tx": False, "is_rx": True},
+        "txrx_set_3": {"id": 3, "is_tx": True, "is_rx": False},
+    }
+
+
 def test_macro_dataset_multi_index_returns_ordered_subset() -> None:
     """Selecting multiple indices should return a MacroDataset in the requested order."""
     g1 = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=0)
@@ -354,6 +364,42 @@ def test_macro_dataset_merge_rejects_multiple_transmitters() -> None:
 
     with pytest.raises(NotImplementedError, match="multiple transmitters"):
         macro.merge()
+
+
+def test_get_idxs_legacy_v3_keeps_primary_rx_grid_native() -> None:
+    """Primary RX grids should keep native row/column semantics in legacy mode."""
+    dataset = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=0)
+    dataset.name = "o1_3p4"
+    dataset.txrx_sets = _make_txrx_sets_dict()
+
+    row_idxs = dataset.get_idxs("legacy_v3", row_idxs=np.array([0]))
+    col_idxs = dataset.get_idxs("legacy_v3", col_idxs=np.array([0]))
+
+    np.testing.assert_array_equal(row_idxs, np.array([0, 1, 2]))
+    np.testing.assert_array_equal(col_idxs, np.array([0, 3]))
+
+
+def test_get_idxs_legacy_v3_swaps_non_primary_rx_grids() -> None:
+    """Non-primary RX grids should reproduce the old v3 row/column convention."""
+    dataset = _make_grid_dataset(nx=4, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=1)
+    dataset.name = "o1_3p4"
+    dataset.txrx_sets = _make_txrx_sets_dict()
+
+    row_idxs = dataset.get_idxs("legacy_v3", row_idxs=np.array([0]))
+    col_idxs = dataset.get_idxs("legacy_v3", col_idxs=np.array([0]))
+
+    np.testing.assert_array_equal(row_idxs, np.array([0, 4]))
+    np.testing.assert_array_equal(col_idxs, np.array([0, 1, 2, 3]))
+
+
+def test_get_idxs_legacy_v3_rejects_non_legacy_scenarios() -> None:
+    """Legacy mode should be explicit and unavailable on regular v4 scenarios."""
+    dataset = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=1)
+    dataset.name = "asu_campus_3p5"
+    dataset.txrx_sets = _make_txrx_sets_dict()
+
+    with pytest.raises(ValueError, match="known legacy scenarios"):
+        dataset.get_idxs("legacy_v3", row_idxs=np.array([0]))
 
 
 def test_validate_txrx_sets_orders_allowed_ids_deterministically() -> None:

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -5,7 +5,7 @@ import pytest
 
 from deepmimo import consts as c
 from deepmimo.datasets.dataset import Dataset, DynamicDataset, MacroDataset, MergedGridDataset
-from deepmimo.datasets.load import _validate_txrx_sets
+from deepmimo.datasets.load import _apply_v3_compat, _validate_txrx_sets
 
 
 @pytest.fixture
@@ -283,16 +283,6 @@ def _make_macro_dataset(*datasets: Dataset) -> MacroDataset:
     return MacroDataset(list(datasets))
 
 
-def _make_txrx_sets_dict() -> dict[str, dict[str, int | bool]]:
-    """Create synthetic TX/RX set metadata with deterministic numeric ids."""
-    return {
-        "txrx_set_0": {"id": 0, "is_tx": False, "is_rx": True},
-        "txrx_set_1": {"id": 1, "is_tx": False, "is_rx": True},
-        "txrx_set_2": {"id": 2, "is_tx": False, "is_rx": True},
-        "txrx_set_3": {"id": 3, "is_tx": True, "is_rx": False},
-    }
-
-
 def test_macro_dataset_multi_index_returns_ordered_subset() -> None:
     """Selecting multiple indices should return a MacroDataset in the requested order."""
     g1 = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=0)
@@ -366,40 +356,49 @@ def test_macro_dataset_merge_rejects_multiple_transmitters() -> None:
         macro.merge()
 
 
-def test_get_idxs_legacy_v3_keeps_primary_rx_grid_native() -> None:
-    """Primary RX grids should keep native row/column semantics in legacy mode."""
-    dataset = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=0)
-    dataset.name = "o1_3p4"
-    dataset.txrx_sets = _make_txrx_sets_dict()
+def test_apply_v3_compat_merges_rx_grids_per_tx_with_global_row_col_semantics() -> None:
+    """compat_v3 should merge RX grids per TX and apply v3 global row/col indexing."""
+    g1 = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=0)
+    g2 = _make_grid_dataset(nx=4, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=1)
+    g3 = _make_grid_dataset(nx=2, ny=3, tx_set_id=0, tx_idx=0, rx_set_id=2)
+    compat = _apply_v3_compat(_make_macro_dataset(g1, g2, g3), rx_rank_map={0: 0, 1: 1, 2: 2})
 
-    row_idxs = dataset.get_idxs("legacy_v3", row_idxs=np.array([0]))
-    col_idxs = dataset.get_idxs("legacy_v3", col_idxs=np.array([0]))
+    assert isinstance(compat, MergedGridDataset)
+    row_idxs = compat.get_idxs("row", row_idxs=np.array([0, 2, 6]))
+    col_idxs = compat.get_idxs("col", col_idxs=np.array([0, 3, 5]))
 
-    np.testing.assert_array_equal(row_idxs, np.array([0, 1, 2]))
-    np.testing.assert_array_equal(col_idxs, np.array([0, 3]))
+    np.testing.assert_array_equal(row_idxs, np.array([0, 1, 2, 6, 10, 14, 16, 18]))
+    np.testing.assert_array_equal(col_idxs, np.array([0, 3, 6, 7, 8, 9, 14, 15]))
 
 
-def test_get_idxs_legacy_v3_swaps_non_primary_rx_grids() -> None:
-    """Non-primary RX grids should reproduce the old v3 row/column convention."""
+def test_apply_v3_compat_single_nonprimary_grid_swaps_row_col() -> None:
+    """compat_v3 should wrap explicit non-primary RX loads with swapped row/col semantics."""
     dataset = _make_grid_dataset(nx=4, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=1)
-    dataset.name = "o1_3p4"
-    dataset.txrx_sets = _make_txrx_sets_dict()
 
-    row_idxs = dataset.get_idxs("legacy_v3", row_idxs=np.array([0]))
-    col_idxs = dataset.get_idxs("legacy_v3", col_idxs=np.array([0]))
+    compat = _apply_v3_compat(dataset, rx_rank_map={0: 0, 1: 1})
 
-    np.testing.assert_array_equal(row_idxs, np.array([0, 4]))
-    np.testing.assert_array_equal(col_idxs, np.array([0, 1, 2, 3]))
+    assert isinstance(compat, MergedGridDataset)
+    np.testing.assert_array_equal(compat.get_idxs("row", row_idxs=np.array([0])), np.array([0, 4]))
+    np.testing.assert_array_equal(
+        compat.get_idxs("col", col_idxs=np.array([0])),
+        np.array([0, 1, 2, 3]),
+    )
 
 
-def test_get_idxs_legacy_v3_rejects_non_legacy_scenarios() -> None:
-    """Legacy mode should be explicit and unavailable on regular v4 scenarios."""
-    dataset = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=1)
-    dataset.name = "asu_campus_3p5"
-    dataset.txrx_sets = _make_txrx_sets_dict()
+def test_apply_v3_compat_returns_one_merged_dataset_per_transmitter() -> None:
+    """compat_v3 should group child datasets by TX before merging receiver grids."""
+    g1 = _make_grid_dataset(nx=3, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=0)
+    g2 = _make_grid_dataset(nx=4, ny=2, tx_set_id=0, tx_idx=0, rx_set_id=1)
+    g3 = _make_grid_dataset(nx=2, ny=3, tx_set_id=1, tx_idx=0, rx_set_id=0)
+    g4 = _make_grid_dataset(nx=2, ny=2, tx_set_id=1, tx_idx=0, rx_set_id=1)
 
-    with pytest.raises(ValueError, match="known legacy scenarios"):
-        dataset.get_idxs("legacy_v3", row_idxs=np.array([0]))
+    compat = _apply_v3_compat(_make_macro_dataset(g1, g2, g3, g4), rx_rank_map={0: 0, 1: 1})
+
+    assert isinstance(compat, MacroDataset)
+    assert len(compat) == 2
+    assert all(isinstance(child, MergedGridDataset) for child in compat.datasets)
+    assert compat[0].n_ue == g1.n_ue + g2.n_ue
+    assert compat[1].n_ue == g3.n_ue + g4.n_ue
 
 
 def test_validate_txrx_sets_orders_allowed_ids_deterministically() -> None:


### PR DESCRIPTION
This PR adds an opt-in v3 compatibility mode for multi-RX-grid scenarios in DeepMIMO v4.

When `compat_v3=True` in `dm.load(...)`, RX grids are merged per TX and row/col indexing follows v3 semantics:
- primary RX grid (rank 0): normal row/col behavior
- non-primary RX grids (rank >= 1): row/col swapped

This is intended to restore backward-compatible user selection behavior for scenarios like `o1_*` and `boston*`, including when `rx_sets` is explicitly provided.

## What Changed
- Added `compat_v3` flag to the loader:
  - `dm.load(scen_name, *, compat_v3=False, **load_params)`
- Added a dedicated v3-compat module:
  - `deepmimo/datasets/compat_v3.py`
- Kept the generic merged-grid machinery in `deepmimo/datasets/dataset.py`
- Added the compat pipeline in the loader for static scenarios:
  - compute RX rank map from scenario metadata
  - merge RX grids per TX
  - compute global row/col offsets and per-grid axis mapping
  - return a merged dataset view with v3-compatible indexing semantics
- Added/updated tests for compat behavior in:
  - `tests/datasets/test_dataset.py`
- Updated the migration guide with the merged-grid compatibility workflow:
  - `docs/tutorials/8_migration_guide.py`

## Behavior Notes
- Default behavior is unchanged when `compat_v3=False`.
- With `compat_v3=True`, compatibility is applied at load time for static scenarios.
- Explicit non-primary RX set loads (for example `rx_sets=[1]`) also use swapped row/col semantics as expected in v3 workflows.
- Dynamic scenarios are not supported under `compat_v3=True`.

## Verification
- `uv run ruff format --check .`
- `uv run ruff check deepmimo/datasets/compat_v3.py deepmimo/datasets/dataset.py deepmimo/datasets/load.py tests/datasets/test_dataset.py docs/tutorials/8_migration_guide.py`
- `uv run pytest tests/datasets/test_dataset.py tests/tutorials/test_8_migration_guide.py`
- manual check on `o1_3p4` with `compat_v3=True` for merged rows `2000`, `3000`, and `4000`

## Example Usage
```python
import deepmimo as dm
import numpy as np

d = dm.load("o1_3p4", tx_sets=[3], compat_v3=True)
idxs = d.get_idxs("row", row_idxs=np.array([2000, 3000, 4000]))
subset = d.trim(idxs=idxs)
```

Explicit RX set (still compat-aware):
```python
d = dm.load("o1_3p4", tx_sets=[3], rx_sets=[1], compat_v3=True)
idxs = d.get_idxs("row", row_idxs=np.arange(0, 10))
subset = d.trim(idxs=idxs)
```
