### PR TITLE
Release DeepMIMO 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1>DeepMIMO</h1>
   <p><i>Bridging ray tracers and 5G/6G simulators with shareable, site-specific datasets</i></p>
   <p>
-    <a href="https://pypi.org/project/deepmimo/"><img alt="PyPI 4.0.0b" src="https://img.shields.io/badge/PyPI-4.0.0b-blue"></a>
+    <a href="https://pypi.org/project/deepmimo/"><img alt="PyPI 4.0.0" src="https://img.shields.io/badge/PyPI-4.0.0-blue"></a>
     <a href="https://www.python.org/"><img alt="Python 3.11+" src="https://img.shields.io/badge/Python-3.11%2B-blue"></a>
     <a href="https://deepmimo.net"><img alt="Docs" src="https://img.shields.io/badge/docs-deepmimo.net-brightgreen"></a>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/github/license/DeepMIMO/DeepMIMO.svg"></a>
@@ -56,7 +56,7 @@
 ### Install
 ```bash
 # From PyPI
-pip install --pre deepmimo
+pip install deepmimo
 
 # From GitHub
 git clone https://github.com/DeepMIMO/DeepMIMO.git

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1>DeepMIMO</h1>
   <p><i>Bridging ray tracers and 5G/6G simulators with shareable, site-specific datasets</i></p>
   <p>
-    <a href="https://pypi.org/project/deepmimo/"><img alt="PyPI 4.0.0" src="https://img.shields.io/badge/PyPI-4.0.0-blue"></a>
+    <a href="https://pypi.org/project/deepmimo/"><img alt="PyPI" src="https://img.shields.io/pypi/v/deepmimo?label=PyPI"></a>
     <a href="https://www.python.org/"><img alt="Python 3.11+" src="https://img.shields.io/badge/Python-3.11%2B-blue"></a>
     <a href="https://deepmimo.net"><img alt="Docs" src="https://img.shields.io/badge/docs-deepmimo.net-brightgreen"></a>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/github/license/DeepMIMO/DeepMIMO.svg"></a>

--- a/deepmimo/__init__.py
+++ b/deepmimo/__init__.py
@@ -1,6 +1,6 @@
 """DeepMIMO Python Package."""
 
-__version__ = "4.0.0b11"
+__version__ = "4.0.0"
 
 # Core functionality
 # Import immediate modules

--- a/docs/api/converter.md
+++ b/docs/api/converter.md
@@ -120,7 +120,7 @@ Conversion from AODT (Aerial Optical Digital Twin) involves 2 steps:
 
 AODT support requires additional dependencies. Install them using:
 ```bash
-pip install --pre deepmimo[aodt]
+pip install deepmimo[aodt]
 ```
 
 ### Exporting

--- a/docs/tutorials/1_getting_started.py
+++ b/docs/tutorials/1_getting_started.py
@@ -26,7 +26,7 @@
 
 # %%
 # Install DeepMIMO (if not already installed)
-# %pip install --pre deepmimo
+# %pip install deepmimo
 
 # %%
 # Import necessary libraries

--- a/docs/tutorials/8_migration_guide.py
+++ b/docs/tutorials/8_migration_guide.py
@@ -92,10 +92,10 @@ print(f"Channel shape: {channels.shape}")
 
 # %%
 # v3: pip install deepmimov3
-# v4: pip install --pre deepmimo
+# v4: pip install deepmimo
 
 print("v3: pip install DeepMIMOv3")
-print("v4: pip install --pre deepmimo")
+print("v4: pip install deepmimo")
 
 # %% [markdown]
 # ### 2. Import Statements
@@ -294,7 +294,7 @@ print("  - Average size reduction: ~50%")
 #
 # Use this checklist when migrating your code:
 #
-# - [ ] Update installation: `pip install --pre deepmimo`
+# - [ ] Update installation: `pip install deepmimo`
 # - [ ] Change import: `import deepmimo as dm`
 # - [ ] Replace `default_params()` with `dm.load()`
 # - [ ] Replace `generate_data()` with `dataset.compute_channels()`

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -22,7 +22,7 @@ Welcome to the DeepMIMO tutorials! These step-by-step guides will help you maste
 
 1. Install DeepMIMO:
    ```bash
-   pip install --pre deepmimo
+   pip install deepmimo
    ```
 
 2. Download a tutorial:

--- a/docs/tutorials/manual.py
+++ b/docs/tutorials/manual.py
@@ -36,14 +36,14 @@
 #
 # ---
 # **How to use this script**:
-# 1. Install DeepMIMO: `pip install --pre deepmimo`
+# 1. Install DeepMIMO: `pip install deepmimo`
 # 2. Run sections interactively in your IDE
 # 3. Jump to the section of interest (see table below)
 # 4. Watch the video explaining the section in detail
 
 # %%
 # Install DeepMIMO (run this in your terminal or uncomment to run here)
-# pip install --pre deepmimo
+# pip install deepmimo
 
 # Import manual-wide dependencies
 
@@ -70,7 +70,7 @@ pydoc.pager = pydoc.plainpager  # when calling help(function), print instead of 
 # | [Migrating from v3](#migrating-from-v3) | [Video](https://youtu.be/15nQWS15h3k) | [Generating v3 Dataset](#generating-v3-dataset) | Usual workflow with DeepMIMO v2/v3 | pip install DeepMIMOv3, default_params(), generate_data() |
 # | | | [Generating v4 Dataset](#generating-v4-dataset) | Usual workflow with DeepMIMO v4 | dm.load(), dataset.compute_channels() |
 # | | | [Comparing v3 & v4](#comparing-v3--v4) | Understand and adapt to new design | dataset.get_row_idxs() |
-# | [Install DeepMIMO](#install-deepmimo) | [Video](https://youtu.be/Mx2aXu9J0pA) | [Python](#python) | Setup in Python using mamba and pip| pip install --pre deepmimo |
+# | [Install DeepMIMO](#install-deepmimo) | [Video](https://youtu.be/Mx2aXu9J0pA) | [Python](#python) | Setup in Python using mamba and pip| pip install deepmimo |
 # | | | [Matlab](#matlab) | Setup in Matlab using pyenv | pyenv, pyrun, pyrunfile |
 # | [Load Dataset](#load-dataset) | [Video](https://youtu.be/LDG6IPEHY54) | [Simple](#simple) | Basic dataset loading method | dm.download(), dm.load() |
 # | | | [Detailed](#detailed) | Advanced dataset loading options | dm.load() with tx_sets, rx_sets, matrices |
@@ -434,7 +434,7 @@ _ = dataset_t.channel.shape
 #   1. `mamba create -n deepmimo_env python=3.11 expat=2.5.0`
 #   2. `mamba activate deepmimo_env`
 # 4. Install DeepMIMO:
-#   - For Users: `pip install --pre deepmimo`
+#   - For Users: `pip install deepmimo`
 #   - For Developers: clone [DeepMIMO](https://github.com/DeepMIMO/DeepMIMO),
 #     go into folder, `pip install -e .`
 
@@ -1895,7 +1895,7 @@ for key in main_keys:
 
 # %%
 # Install DeepMIMO in the Notebook (with AODT dependencies)
-# pip install --pre deepmimo[aodt]
+# pip install deepmimo[aodt]
 
 # %%
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Telecommunications Industry",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
     "Operating System :: OS Independent"
 ]
 dependencies = [
@@ -35,7 +37,11 @@ include = ["deepmimo*"]
 exclude = ["deepmimo_v3*", "deepmimo_v3.*"]
 
 [project.urls]
-Homepage = "https://deepmimo.net/" 
+Homepage = "https://deepmimo.net/"
+Documentation = "https://deepmimo.net/documentation"
+Repository = "https://github.com/DeepMIMO/DeepMIMO"
+Issues = "https://github.com/DeepMIMO/DeepMIMO/issues"
+Releases = "https://github.com/DeepMIMO/DeepMIMO/releases"
 
 [project.optional-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "DeepMIMO"
-version = "4.0.0b11"
+version = "4.0.0"
 authors = [
     { name = "João Morais" },
     { name = "Umut Demirhan" },
@@ -17,7 +17,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 keywords = ["MIMO", "ray tracing", "dataset", "DeepMIMO", "raytracing", "wireless"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Telecommunications Industry",
     "Operating System :: OS Independent"

--- a/scripts/pipelines/pipeline_params.py
+++ b/scripts/pipelines/pipeline_params.py
@@ -2,7 +2,7 @@
 
 Steps to run a pipeline:
 
-1. pip install --pre deepmimo
+1. pip install deepmimo
 
 2. Install dependencies
 	- install miniforge (https://github.com/conda-forge/miniforge)

--- a/uv.lock
+++ b/uv.lock
@@ -683,7 +683,7 @@ wheels = [
 
 [[package]]
 name = "deepmimo"
-version = "4.0.0b11"
+version = "4.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary
- bump the package metadata from `4.0.0b11` to the stable `4.0.0` release
- update the README, tutorials, migration guide, and converter docs to use stable `pip install deepmimo` instructions
- sync `uv.lock` with the new local package version so release builds use aligned metadata

## Test plan
- [x] `uv run pytest tests/tutorials/test_1_getting_started.py tests/tutorials/test_8_migration_guide.py`
- [x] `uv run ruff check deepmimo/__init__.py docs/tutorials/1_getting_started.py docs/tutorials/8_migration_guide.py docs/tutorials/manual.py`
- [ ] Build distribution artifacts before PyPI publish

Made with [Cursor](https://cursor.com)