### PR TITLE
Add DATASET_VERSION to params, upload, and download

### DIFF
--- a/deepmimo/api/download.py
+++ b/deepmimo/api/download.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import requests
 from tqdm import tqdm
 
+from deepmimo import consts as c
 from deepmimo.utils import (
     get_rt_source_folder,
     get_rt_sources_dir,
@@ -32,11 +33,14 @@ from deepmimo.utils import (
 from ._common import API_BASE_URL, HEADERS, REQUEST_TIMEOUT
 
 
-def _download_url(scenario_name: str, *, rt_source: bool = False) -> str:
+def _download_url(
+    scenario_name: str, *, version: str = c.DATASET_VERSION, rt_source: bool = False
+) -> str:
     """Get the secure download endpoint URL for a DeepMIMO scenario.
 
     Args:
         scenario_name: Name of the scenario ZIP file
+        version: Dataset version to request (defaults to current DATASET_VERSION).
         rt_source: Whether to download the raytracing source file
 
     Returns:
@@ -50,14 +54,16 @@ def _download_url(scenario_name: str, *, rt_source: bool = False) -> str:
     if not scenario_name.endswith(".zip"):
         scenario_name += ".zip"
 
-    # Return the secure download endpoint URL with the filename as a parameter
     rt_param = "&rt_source=true" if rt_source else ""
-    return f"{API_BASE_URL}/api/download/secure?filename={scenario_name}{rt_param}"
+    base = f"{API_BASE_URL}/api/download/secure?filename={scenario_name}&version={version}"
+    return base + rt_param
 
 
-def download_url(scenario_name: str, *, rt_source: bool = False) -> str:
+def download_url(
+    scenario_name: str, *, version: str = c.DATASET_VERSION, rt_source: bool = False
+) -> str:
     """Public wrapper around `_download_url`."""
-    return _download_url(scenario_name, rt_source=rt_source)
+    return _download_url(scenario_name, version=version, rt_source=rt_source)
 
 
 def _resolve_download_paths(
@@ -228,6 +234,7 @@ def download(
     scenario_name: str,
     output_dir: str | None = None,
     *,
+    version: str = c.DATASET_VERSION,
     rt_source: bool = False,
 ) -> str | None:
     """Download a DeepMIMO scenario from the database.
@@ -235,6 +242,9 @@ def download(
     Args:
         scenario_name: Name of the scenario
         output_dir: Directory to save file (defaults to current directory)
+        version: Dataset version to request. Defaults to the current DATASET_VERSION
+            constant so most users never need to set this. Pass an explicit value
+            (e.g. ``"4a"``) to pin a specific build.
         rt_source: Whether to download the raytracing source file instead of the scenario
 
     Returns:
@@ -256,7 +266,7 @@ def download(
         download_type = "raytracing source" if rt_source else "scenario"
         print(f"Downloading {download_type} '{scenario_name}'")
 
-        url = _download_url(scenario_name, rt_source=rt_source)
+        url = _download_url(scenario_name, version=version, rt_source=rt_source)
         if not _download_file_from_server(url, output_path):
             return None
     else:

--- a/deepmimo/api/upload.py
+++ b/deepmimo/api/upload.py
@@ -269,7 +269,7 @@ def _process_params_data(params_dict: dict, extra_metadata: dict | None = None) 
     }
 
     advanced_params = {
-        "dmVersion": params_dict.get("version", "4.0.0a"),
+        "dmVersion": params_dict.get(c.DATASET_VERSION_PARAM_NAME, c.DATASET_VERSION),
         "numTx": num_tx,
         "multiRxAnt": any(
             set_info.get("num_ant", 0) > 1

--- a/deepmimo/consts.py
+++ b/deepmimo/consts.py
@@ -57,6 +57,11 @@ from . import __version__
 VERSION_PARAM_NAME = "version"
 VERSION = __version__
 
+# Dataset version — tracks the dataset schema/format independently of the software version.
+# Increment the letter suffix (4a → 4b → …) when the on-disk format changes in a way
+# that requires a new download; the server uses this to return the correct dataset build.
+DATASET_VERSION = "4a"
+
 # File and folder paths
 SCENARIOS_FOLDER = "deepmimo_scenarios"  # Folder containing scenarios (extracted and ZIPs)
 RT_SOURCES_FOLDER = "deepmimo_rt_sources"  # Folder containing ray tracing source files

--- a/deepmimo/consts.py
+++ b/deepmimo/consts.py
@@ -60,6 +60,7 @@ VERSION = __version__
 # Dataset version — tracks the dataset schema/format independently of the software version.
 # Increment the letter suffix (4a → 4b → …) when the on-disk format changes in a way
 # that requires a new download; the server uses this to return the correct dataset build.
+DATASET_VERSION_PARAM_NAME = "dataset_version"
 DATASET_VERSION = "4a"
 
 # File and folder paths

--- a/deepmimo/converters/aodt/aodt_converter.py
+++ b/deepmimo/converters/aodt/aodt_converter.py
@@ -109,6 +109,7 @@ def aodt_rt_converter(  # noqa: PLR0913
     # Save parameters to params.json
     params = {
         c.VERSION_PARAM_NAME: c.VERSION,
+        c.DATASET_VERSION_PARAM_NAME: c.DATASET_VERSION,
         c.RT_PARAMS_PARAM_NAME: rt_params,
         c.TXRX_PARAM_NAME: txrx_dict,
         c.MATERIALS_PARAM_NAME: materials_dict,

--- a/deepmimo/converters/sionna_rt/sionna_converter.py
+++ b/deepmimo/converters/sionna_rt/sionna_converter.py
@@ -111,6 +111,7 @@ def sionna_rt_converter(  # noqa: PLR0913
     # Save parameters to params.json
     params = {
         c.VERSION_PARAM_NAME: c.VERSION,
+        c.DATASET_VERSION_PARAM_NAME: c.DATASET_VERSION,
         c.RT_PARAMS_PARAM_NAME: rt_params,
         c.TXRX_PARAM_NAME: txrx_dict,
         c.MATERIALS_PARAM_NAME: materials_dict,

--- a/deepmimo/converters/wireless_insite/insite_converter.py
+++ b/deepmimo/converters/wireless_insite/insite_converter.py
@@ -128,6 +128,7 @@ def insite_rt_converter(  # noqa: PLR0913
     # Save parameters to params.json
     params = {
         c.VERSION_PARAM_NAME: c.VERSION,
+        c.DATASET_VERSION_PARAM_NAME: c.DATASET_VERSION,
         c.RT_PARAMS_PARAM_NAME: rt_params,
         c.TXRX_PARAM_NAME: txrx_dict,
         c.MATERIALS_PARAM_NAME: materials_dict,


### PR DESCRIPTION
## Summary

Implements the dataset versioning scheme discussed with @sohamd22.

**Three changes:**

1. **`consts.py`** — adds `DATASET_VERSION_PARAM_NAME = "dataset_version"` alongside the existing `DATASET_VERSION = "4a"` constant
2. **All three converters** (Sionna RT, AODT, Wireless InSite) — write `dataset_version` into `params.json` at conversion time, so every scenario carries its schema version on disk
3. **`upload.py`** — `dmVersion` now reads from the dedicated `dataset_version` field in params (falls back to `DATASET_VERSION` constant if absent, for backwards compatibility)
4. **`download.py`** — `download()` gains a `version=` keyword argument (default `DATASET_VERSION`) appended to the URL as `?version=4a`, so the server can route to the correct dataset build

## Open question for @sohamd22

Is including `dataset_version` in the upload call redundant given the server already reads it from `params.json`? Current thinking: keep it in both places — the params file is the canonical source, but passing it explicitly in the upload call gives the server a fast path without having to parse the params file first, and makes the intent obvious at the API boundary. Happy to drop it from the upload if you prefer simpler server-side logic.

## Test plan

- [ ] Convert a scenario and verify `params.json` contains `"dataset_version": "4a"`
- [ ] Confirm `upload()` sends `"dmVersion": "4a"` in `advanced_params`
- [ ] Confirm `download("scenario_name")` hits `?version=4a` by default
- [ ] Confirm `download("scenario_name", version="4b")` hits `?version=4b`
