### PR TITLE
Add ruff pre-commit hook mirroring CI gates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# Pre-commit hooks for DeepMIMO.
+#
+# Mirrors the CI quality gates in .github/workflows/ci.yml (`ruff check .` and
+# `ruff format --check .`) so formatting/lint issues are caught locally before
+# they can fail CI. Ruff auto-discovers [tool.ruff] in pyproject.toml, so the
+# line length, rule selection and excludes (e.g. scripts/) apply identically.
+#
+# Enable once per clone:
+#     pre-commit install
+# Run manually against the whole repo:
+#     pre-commit run --all-files
+# Bump the pinned hook version (keep it in step with the ruff pin in pyproject):
+#     pre-commit autoupdate
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.8
+    hooks:
+      # Linter (with autofix) — mirrors `ruff check .`
+      - id: ruff-check
+        args: [--fix]
+      # Formatter — mirrors `ruff format --check .`
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "nbmake>=1.5.0",
     "ruff>=0.6.9",
+    "pre-commit>=3.5",
     "deepmimov3",
 
     # Documentation
@@ -169,6 +170,7 @@ all = [
     "mkdocs-autorefs>=1.2",
     "mkdocs-exclude>=1.0",
     "ruff>=0.6.9",
+    "pre-commit>=3.5",
     "jupyter-core>=5.7,<6.0",
     "jupyter-client>=8.6.3",
     "platformdirs>=4.3.0",


### PR DESCRIPTION
## Summary

Adds a pre-commit hook so ruff lint + format run locally before each commit, mirroring the CI quality gates (`ruff check .` and `ruff format --check .`). This catches formatting/lint issues before they can fail CI.

- `.pre-commit-config.yaml` — runs `ruff-check` (with `--fix`) and `ruff-format`, pinned to `v0.14.8` (the ruff version CI resolves). The hooks reuse `[tool.ruff]` from `pyproject.toml`, so they enforce exactly what CI checks (same rule set, line length, and `scripts/` exclude).
- Adds `pre-commit` to the `[dev]` and `[all]` extras.

Enable once per clone:

```bash
pip install -e .[dev]   # or: uv sync --extra dev
pre-commit install
```

## Test plan

- [x] `pre-commit run --all-files` → `ruff-check` and `ruff-format` both pass on the current tree
- [x] Hook IDs verified against `ruff-pre-commit` v0.14.8 (`ruff-check`, `ruff-format`)