### PR TITLE
Add optional lossless (mesh) scene format and remove roads

### DIFF
--- a/deepmimo/consts.py
+++ b/deepmimo/consts.py
@@ -142,6 +142,15 @@ SCENE_PARAM_N_VERTICES = "n_vertices"
 SCENE_PARAM_N_FACES = "n_faces"
 SCENE_PARAM_N_TRIANGULAR_FACES = "n_triangular_faces"
 
+# Scene geometry representation (how object faces are stored on disk)
+SCENE_PARAM_REPRESENTATION = "representation"
+SCENE_REPRESENTATION_HULL = "hull"  # Default/legacy convex-hull simplification
+SCENE_REPRESENTATION_MESH = "mesh"  # Lossless triangular mesh (preserves geometry)
+
+# Filenames for the lossless triangular-mesh representation
+SCENE_MESH_FACES_FILENAME = "faces.npz"  # Per-object (N_tri, 3) vertex-index arrays
+SCENE_MESH_MATERIALS_FILENAME = "materials.npz"  # Per-object (N_tri,) material-index arrays
+
 # ==============================================================================
 # 4. Materials Parameters
 # ==============================================================================

--- a/deepmimo/converters/aodt/aodt_converter.py
+++ b/deepmimo/converters/aodt/aodt_converter.py
@@ -40,6 +40,7 @@ def aodt_rt_converter(  # noqa: PLR0913
     print_params: bool = True,
     parent_folder: str = "",
     num_scenes: int = 1,
+    lossless: bool = False,
 ) -> str:
     """Convert AODT ray-tracing data to DeepMIMO format.
 
@@ -56,6 +57,8 @@ def aodt_rt_converter(  # noqa: PLR0913
         print_params (bool): Whether to print parameters to console. Defaults to True.
         parent_folder (str): Parent folder for time-varying scenarios. Defaults to empty.
         num_scenes (int): Number of scenes in time-varying scenario. Defaults to 1.
+        lossless (bool): If True, export the scene as a lossless triangular mesh
+            instead of the default convex-hull representation. Defaults to False.
 
     Returns:
         str: Path to output folder containing converted DeepMIMO dataset.
@@ -97,7 +100,7 @@ def aodt_rt_converter(  # noqa: PLR0913
     # Read Scene data from world.parquet
     if False:
         scene = read_scene(rt_folder)
-        scene_dict = scene.export_data(temp_folder) if scene else {}
+        scene_dict = scene.export_data(temp_folder, lossless=lossless) if scene else {}
     else:
         scene, scene_dict = None, {}
     scene_dict[c.SCENE_PARAM_NUMBER_SCENES] = num_scenes

--- a/deepmimo/converters/converter.py
+++ b/deepmimo/converters/converter.py
@@ -62,7 +62,10 @@ def convert(path_to_rt_folder: str, **conversion_params: dict[str, Any]) -> str 
         path_to_rt_folder (str): Path to the folder containing raytracing data.
                                  If the folder contains multiple scenes, the function will
                                  sort them with sorted() and convert each folder to a time snapshot.
-        **conversion_params (dict[str, Any]): Additional parameters for the conversion process
+        **conversion_params (dict[str, Any]): Additional parameters for the conversion process.
+            Forwarded verbatim to the selected ray-tracer converter. Notably,
+            ``lossless=True`` requests the lossless triangular-mesh scene export
+            (default is the compact convex-hull representation).
 
     Returns:
         Optional[Any]: Scenario object if conversion is successful, None otherwise

--- a/deepmimo/converters/sionna_rt/sionna_converter.py
+++ b/deepmimo/converters/sionna_rt/sionna_converter.py
@@ -32,6 +32,7 @@ def sionna_rt_converter(  # noqa: PLR0913
     num_scenes: int = 1,
     deduplicate: bool = True,
     overlap_threshold: float = 0.8,
+    lossless: bool = False,
 ) -> str:
     """Convert Sionna ray-tracing data to DeepMIMO format.
 
@@ -56,6 +57,8 @@ def sionna_rt_converter(  # noqa: PLR0913
             Defaults to True.
         overlap_threshold (float): AABB overlap fraction threshold for deduplication.
             Defaults to 0.8.
+        lossless (bool): If True, export the scene as a lossless triangular mesh
+            instead of the default convex-hull representation. Defaults to False.
 
     Returns:
         str: Path to output folder containing converted DeepMIMO dataset.
@@ -101,7 +104,7 @@ def sionna_rt_converter(  # noqa: PLR0913
         deduplicate=deduplicate,
         overlap_threshold=overlap_threshold,
     )
-    scene_dict = scene.export_data(temp_folder) if scene else {}
+    scene_dict = scene.export_data(temp_folder, lossless=lossless) if scene else {}
     scene_dict[c.SCENE_PARAM_NUMBER_SCENES] = num_scenes
 
     # Visualize if requested

--- a/deepmimo/converters/sionna_rt/sionna_scene.py
+++ b/deepmimo/converters/sionna_rt/sionna_scene.py
@@ -21,8 +21,8 @@ from deepmimo.core.scene import (
 )
 from deepmimo.utils import load_pickle
 
-# (vertices, material_idx, label, name, use_fast)
-_Component = tuple[np.ndarray, int, str, str, bool]
+# (vertices, material_idx, label, name)
+_Component = tuple[np.ndarray, int, str, str]
 
 
 def _split_into_components(
@@ -109,7 +109,7 @@ def _cluster_by_aabb(
     Only components sharing the same scene label are considered for merging.
 
     Args:
-        components: Sequence of ``(vertices, material_idx, label, name, use_fast)``
+        components: Sequence of ``(vertices, material_idx, label, name)``
             tuples.
         overlap_threshold: Fraction of the smaller AABB volume that must lie
             inside the larger AABB to trigger a merge.  Default 0.8.
@@ -224,8 +224,7 @@ def read_scene(
 
             for comp_idx, comp_verts in enumerate(components):
                 comp_name = name if n_comps == 1 else f"{name}_{comp_idx}"
-                use_fast = "road" not in comp_name.lower()
-                all_components.append((comp_verts, material_idx, obj_label, comp_name, use_fast))
+                all_components.append((comp_verts, material_idx, obj_label, comp_name))
 
         except Exception as e:
             print(f"Error processing object {name}: {e!s}")
@@ -241,10 +240,9 @@ def read_scene(
     obj_counter = 0
     for cluster in clusters:
         merged_verts = np.vstack([all_components[k][0] for k in cluster])
-        _, material_idx, obj_label, comp_name, _ = all_components[cluster[0]]
-        use_fast = "road" not in comp_name.lower()
+        _, material_idx, obj_label, comp_name = all_components[cluster[0]]
 
-        generated_faces = get_object_faces(merged_verts, fast=use_fast)
+        generated_faces = get_object_faces(merged_verts)
         if generated_faces is None:
             continue
 

--- a/deepmimo/converters/wireless_insite/insite_converter.py
+++ b/deepmimo/converters/wireless_insite/insite_converter.py
@@ -57,6 +57,7 @@ def insite_rt_converter(  # noqa: PLR0913
     print_params: bool = True,
     parent_folder: str = "",
     num_scenes: int = 1,
+    lossless: bool = False,
 ) -> str:
     """Convert Wireless InSite ray-tracing data to DeepMIMO format.
 
@@ -76,6 +77,8 @@ def insite_rt_converter(  # noqa: PLR0913
             This parameter is only used if the scenario is time-varying.
         num_scenes (int): Number of scenes in the scenario. Defaults to 1.
                           This parameter is only used if the scenario is time-varying.
+        lossless (bool): If True, export the scene as a lossless triangular mesh
+            instead of the default convex-hull representation. Defaults to False.
 
     Returns:
         str: Path to output folder containing converted DeepMIMO dataset.
@@ -118,7 +121,7 @@ def insite_rt_converter(  # noqa: PLR0913
 
     # Read scene objects
     scene = read_scene(rt_folder)
-    scene_dict = scene.export_data(temp_folder)
+    scene_dict = scene.export_data(temp_folder, lossless=lossless)
     scene_dict[c.SCENE_PARAM_NUMBER_SCENES] = num_scenes
 
     # Visualize if requested

--- a/deepmimo/converters/wireless_insite/insite_scene.py
+++ b/deepmimo/converters/wireless_insite/insite_scene.py
@@ -7,7 +7,6 @@ from Wireless InSite into DeepMIMO's physical object representation.
 import re
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import numpy as np
 from tqdm import tqdm
 
@@ -31,7 +30,6 @@ OBJECT_LABELS: dict[str, str] = {
     ".flp": CAT_FLOORPLANS,
     ".obj": CAT_OBJECTS,
 }
-MIN_TRI_POINTS = 3
 
 
 def read_scene(folder_path: str | Path) -> Scene:
@@ -85,71 +83,6 @@ def read_scene(folder_path: str | Path) -> Scene:
     return scene
 
 
-def visualize_road_object(
-    name: str,
-    vertices: np.ndarray,
-    faces: list[list[tuple[float, float, float]]],
-) -> None:
-    """Visualize a road object and its generated faces."""
-    # Save vertices for testing
-    save_path = f"road_vertices_{name.replace(' ', '_')}.npy"
-    np.save(save_path, vertices)
-    print(f"Saved vertices to {save_path}")
-
-    fig = plt.figure(figsize=(15, 5))
-
-    # Plot original vertices
-    ax1 = fig.add_subplot(121, projection="3d")
-    ax1.scatter(vertices[:, 0], vertices[:, 1], vertices[:, 2], c="b", marker="o")
-    ax1.set_title(f"Original Vertices\n{name}")
-
-    # Plot generated faces
-    if faces:
-        ax2 = fig.add_subplot(122, projection="3d")
-        print(f"\nAnalyzing faces for {name}:")
-        for i, face in enumerate(faces):
-            face_array = np.array(face)
-            print(f"Face {i}:")
-            print(f"  Vertices: {len(face)}")
-            print(f"  Unique XY points: {len(np.unique(face_array[:, :2], axis=0))}")
-            print(f"  Z range: {face_array[:, 2].min():.3f} to {face_array[:, 2].max():.3f}")
-
-            # Plot face as a line connecting vertices
-            face_array_closed = np.vstack([face_array, face_array[0]])  # Close the loop
-            ax2.plot(
-                face_array_closed[:, 0],
-                face_array_closed[:, 1],
-                face_array_closed[:, 2],
-                "-o",
-                alpha=0.5,
-            )
-
-            # Fill face if it has at least 3 unique points
-            unique_points = np.unique(face_array[:, :2], axis=0)
-            if len(unique_points) >= MIN_TRI_POINTS:
-                try:
-                    from matplotlib.tri import Triangulation  # noqa: PLC0415
-
-                    tri = Triangulation(face_array[:, 0], face_array[:, 1])
-                    ax2.plot_trisurf(
-                        face_array[:, 0],
-                        face_array[:, 1],
-                        face_array[:, 2],
-                        triangles=tri.triangles,
-                        alpha=0.2,
-                    )
-                except (ImportError, ValueError, RuntimeError) as err:
-                    print(f"  Warning: Could not triangulate face: {err!s}")
-            else:
-                print("  Warning: Face has fewer than 3 unique points in XY plane")
-
-        ax2.set_title("Generated Faces")
-
-    plt.tight_layout()
-    plt.savefig(f"road_debug_{name.replace(' ', '_')}.png")
-    plt.close()
-
-
 class PhysicalObjectParser:
     """Parser for Wireless InSite physical object files (.city, .ter, .veg)."""
 
@@ -170,7 +103,7 @@ class PhysicalObjectParser:
         self.name = self.file_path.stem  # Get filename without extension
         self.starting_id = starting_id
 
-    def parse(self, *, force_fast_mode: bool = True) -> list[PhysicalElement]:
+    def parse(self) -> list[PhysicalElement]:
         """Parse the file and return a list of physical objects.
 
         Returns:
@@ -196,12 +129,10 @@ class PhysicalObjectParser:
         ):
             vertices_array = np.array(vertices)
 
-            # Use detailed mode for roads to preserve their geometry
-            use_fast_mode = "road" not in self.name.lower()
             self.name = f"{self.name}_{i}"
 
-            # Generate faces
-            object_faces = get_object_faces(vertices_array, fast=use_fast_mode or force_fast_mode)
+            # Generate faces using the convex-hull approach
+            object_faces = get_object_faces(vertices_array)
             if object_faces is None:
                 print(f"Failed to generate faces for object {self.name}")
                 continue

--- a/deepmimo/core/scene.py
+++ b/deepmimo/core/scene.py
@@ -622,6 +622,10 @@ class Scene:
         self.visualization_settings = self.DEFAULT_VISUALIZATION_SETTINGS.copy()
         self.face_indices = []
         self._current_index = 0
+        # Geometry representation of the loaded scene. Defaults to the convex-hull
+        # ("hull") simplification; set to "mesh" only when reconstructed from the
+        # lossless triangular-mesh files (see ``_from_data_mesh``).
+        self.representation: str = SCENE_REPRESENTATION_HULL
         self._objects_by_category: dict[str, list[PhysicalElement]] = {
             cat: [] for cat in ELEMENT_CATEGORIES
         }
@@ -884,6 +888,7 @@ class Scene:
 
         """
         scene = cls()
+        scene.representation = SCENE_REPRESENTATION_MESH
         faces_path = f"{base_folder}/{SCENE_MESH_FACES_FILENAME}"
         materials_path = f"{base_folder}/{SCENE_MESH_MATERIALS_FILENAME}"
         try:

--- a/deepmimo/core/scene.py
+++ b/deepmimo/core/scene.py
@@ -1,13 +1,13 @@
 """Physical world representation module.
 
 Provides geometry classes (BoundingBox, Face, PhysicalElement, PhysicalElementGroup, Scene)
-and helper routines for road/mesh handling (2D face generation, endpoint detection, trimming,
-path compression, angle deviation, intersection checks, and TSP path ordering).
+and helpers for generating object faces via convex-hull simplification. Scenes can be exported
+either in the default convex-hull ("hull") representation or in a lossless triangular-mesh
+("mesh") representation that preserves the original geometry.
 """
 
 from __future__ import annotations
 
-import itertools
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
@@ -17,7 +17,21 @@ import numpy as np
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 from scipy.spatial import ConvexHull
 
-from deepmimo.consts import MAT_FMT, SCENE_PARAM_NUMBER_SCENES
+from deepmimo.consts import (
+    MAT_FMT,
+    PARAMS_FILENAME,
+    SCENE_MESH_FACES_FILENAME,
+    SCENE_MESH_MATERIALS_FILENAME,
+    SCENE_PARAM_N_FACES,
+    SCENE_PARAM_N_OBJECTS,
+    SCENE_PARAM_N_TRIANGULAR_FACES,
+    SCENE_PARAM_N_VERTICES,
+    SCENE_PARAM_NAME,
+    SCENE_PARAM_NUMBER_SCENES,
+    SCENE_PARAM_REPRESENTATION,
+    SCENE_REPRESENTATION_HULL,
+    SCENE_REPRESENTATION_MESH,
+)
 from deepmimo.utils import (
     DelegatingList,
     load_dict_from_json,
@@ -359,6 +373,79 @@ class PhysicalElement:
         ]
         return cls(faces=faces, name=data["name"], object_id=data["id"], label=data["label"])
 
+    def to_mesh_arrays(
+        self,
+        vertex_map: dict[tuple[float, ...], int],
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Serialize the object as a lossless triangular mesh.
+
+        Unlike :meth:`to_dict` (which stores simplified convex-hull faces), this
+        preserves the object's exact geometry by emitting one entry per triangle.
+        Vertices are deduplicated through the shared ``vertex_map``, mirroring how
+        :meth:`Scene.export_data` builds its global vertex pool.
+
+        Args:
+            vertex_map: Dictionary mapping vertex tuples to their global indices.
+                Updated in place as new vertices are encountered.
+
+        Returns:
+            tuple[np.ndarray, np.ndarray]:
+                - tri_vertex_idxs: int array of shape (N_triangles, 3) with the
+                  global vertex indices of each triangle.
+                - tri_material_idxs: int array of shape (N_triangles,) with the
+                  material index of each triangle.
+
+        """
+        tri_vertex_idxs: list[list[int]] = []
+        tri_material_idxs: list[int] = []
+        for face in self.faces:
+            for triangle in face.triangular_faces:
+                triangle_indices = []
+                for vertex in triangle:
+                    vertex_tuple = tuple(vertex)
+                    if vertex_tuple not in vertex_map:
+                        vertex_map[vertex_tuple] = len(vertex_map)
+                    triangle_indices.append(vertex_map[vertex_tuple])
+                tri_vertex_idxs.append(triangle_indices)
+                tri_material_idxs.append(face.material_idx)
+        return (
+            np.array(tri_vertex_idxs, dtype=np.int32).reshape(-1, 3),
+            np.array(tri_material_idxs, dtype=np.int32),
+        )
+
+    @classmethod
+    def from_mesh_arrays(
+        cls: PhysicalElement,
+        data: dict,
+        tri_vertex_idxs: np.ndarray,
+        tri_material_idxs: np.ndarray,
+        vertices: np.ndarray,
+    ) -> PhysicalElement:
+        """Create a physical object from a lossless triangular mesh.
+
+        Each triangle becomes its own :class:`Face`, preserving the exact geometry
+        that was exported with ``Scene.export_data(..., lossless=True)``.
+
+        Args:
+            data: Dictionary containing object metadata (name, label, id).
+            tri_vertex_idxs: int array (N_triangles, 3) of global vertex indices.
+            tri_material_idxs: int array (N_triangles,) of material indices.
+            vertices: Array of vertex coordinates (shape: N_vertices x 3).
+
+        Returns:
+            PhysicalElement: Created object with one Face per triangle.
+
+        """
+        faces = [
+            Face(vertices=vertices[triangle_idxs], material_idx=int(material_idx))
+            for (triangle_idxs, material_idx) in zip(
+                tri_vertex_idxs,
+                tri_material_idxs,
+                strict=False,
+            )
+        ]
+        return cls(faces=faces, name=data["name"], object_id=data["id"], label=data["label"])
+
     @property
     def position(self) -> np.ndarray:
         """Get the center of mass (position) of the object."""
@@ -624,20 +711,35 @@ class Scene:
         group = PhysicalElementGroup(objects)
         return group.get_objects(material=material) if material else group
 
-    def export_data(self, base_folder: str) -> dict:
+    def export_data(self, base_folder: str, *, lossless: bool = False) -> dict:
         """Export scene data to files and return metadata dictionary.
 
-        Creates matrix files for vertices, faces and materials in the base folder.
-        Returns a dictionary containing metadata needed to reload the scene.
+        Two on-disk representations are supported:
+
+        - Hull (default, ``lossless=False``): the legacy convex-hull representation.
+          Writes ``vertices.npz`` (the global deduplicated vertex pool) and
+          ``objects.json`` (per-object convex-hull faces). Compact and unchanged from
+          previous versions.
+        - Mesh (``lossless=True``): a lossless triangular mesh that preserves the
+          exact geometry. Writes the same ``vertices.npz`` pool plus ``faces.npz``
+          (one ``(N_tri, 3)`` vertex-index array per object) and ``materials.npz``
+          (one ``(N_tri,)`` material-index array per object). Object metadata is
+          stored in ``objects.json``.
 
         Args:
-            base_folder: Base folder to store matrix files
+            base_folder: Base folder to store the scene files.
+            lossless: If True, export the lossless triangular mesh instead of the
+                convex-hull simplification. Defaults to False.
 
         Returns:
-            Dict containing metadata needed to reload the scene
+            Dict containing metadata needed to reload the scene (including the
+            ``representation`` flag).
 
         """
         Path(base_folder).mkdir(parents=True, exist_ok=True)
+        if lossless:
+            return self._export_data_mesh(base_folder)
+
         vertex_map = {}
         objects_metadata = []
         for obj in self.objects:
@@ -651,20 +753,78 @@ class Scene:
         save_dict_as_json(f"{base_folder}/objects.json", objects_metadata)
         return {
             SCENE_PARAM_NUMBER_SCENES: 1,
-            "n_objects": len(self.objects),
-            "n_vertices": len(vertices),
-            "n_faces": sum(len(obj.faces) for obj in self.objects),
-            "n_triangular_faces": sum(len(obj_face_idxs) for obj_face_idxs in self.face_indices),
+            SCENE_PARAM_N_OBJECTS: len(self.objects),
+            SCENE_PARAM_N_VERTICES: len(vertices),
+            SCENE_PARAM_N_FACES: sum(len(obj.faces) for obj in self.objects),
+            SCENE_PARAM_N_TRIANGULAR_FACES: sum(
+                len(obj_face_idxs) for obj_face_idxs in self.face_indices
+            ),
+            SCENE_PARAM_REPRESENTATION: SCENE_REPRESENTATION_HULL,
+        }
+
+    def _export_data_mesh(self, base_folder: str) -> dict:
+        """Export the scene as a lossless triangular mesh.
+
+        See :meth:`export_data` for the on-disk layout and rationale.
+
+        Args:
+            base_folder: Base folder to store the scene files.
+
+        Returns:
+            Dict containing metadata needed to reload the scene.
+
+        """
+        vertex_map: dict[tuple[float, ...], int] = {}
+        objects_metadata = []
+        faces_arrays: dict[str, np.ndarray] = {}
+        materials_arrays: dict[str, np.ndarray] = {}
+        n_triangular_faces = 0
+        for obj_idx, obj in enumerate(self.objects):
+            mesh_key = str(obj_idx)
+            tri_vertex_idxs, tri_material_idxs = obj.to_mesh_arrays(vertex_map)
+            faces_arrays[mesh_key] = tri_vertex_idxs
+            materials_arrays[mesh_key] = tri_material_idxs
+            n_triangular_faces += len(tri_vertex_idxs)
+            objects_metadata.append(
+                {
+                    "name": obj.name,
+                    "label": obj.label,
+                    "id": obj.object_id,
+                    "mesh_key": mesh_key,
+                },
+            )
+        all_vertices = [None] * len(vertex_map)
+        for vertex, idx in vertex_map.items():
+            all_vertices[idx] = vertex
+        vertices = np.array(all_vertices) if all_vertices else np.zeros((0, 3), dtype=np.float32)
+        save_mat(vertices, "vertices", f"{base_folder}/vertices.mat")
+        np.savez_compressed(f"{base_folder}/{SCENE_MESH_FACES_FILENAME}", **faces_arrays)
+        np.savez_compressed(f"{base_folder}/{SCENE_MESH_MATERIALS_FILENAME}", **materials_arrays)
+        save_dict_as_json(f"{base_folder}/objects.json", objects_metadata)
+        return {
+            SCENE_PARAM_NUMBER_SCENES: 1,
+            SCENE_PARAM_N_OBJECTS: len(self.objects),
+            SCENE_PARAM_N_VERTICES: len(vertices),
+            SCENE_PARAM_N_FACES: sum(len(obj.faces) for obj in self.objects),
+            SCENE_PARAM_N_TRIANGULAR_FACES: n_triangular_faces,
+            SCENE_PARAM_REPRESENTATION: SCENE_REPRESENTATION_MESH,
         }
 
     @classmethod
     def from_data(cls: Any, base_folder: str) -> Scene:
-        """Create scene from metadata dictionary and data files.
+        """Create scene from data files.
+
+        Detects the scene representation (convex-hull ``"hull"`` or lossless
+        ``"mesh"``) and reconstructs the objects accordingly. Scenarios without an
+        explicit representation flag (legacy datasets) are loaded as ``"hull"``.
 
         Args:
-            base_folder: Base folder containing matrix files
+            base_folder: Base folder containing the scene files.
 
         """
+        if cls._is_mesh_representation(base_folder):
+            return cls._from_data_mesh(base_folder)
+
         scene = cls()
         try:
             vertices = load_mat(f"{base_folder}/vertices.{MAT_FMT}", "vertices")
@@ -681,6 +841,76 @@ class Scene:
             raise RuntimeError(msg) from e
         for object_data in objects_metadata:
             obj = PhysicalElement.from_dict(object_data, vertices)
+            scene.add_object(obj)
+        return scene
+
+    @staticmethod
+    def _is_mesh_representation(base_folder: str) -> bool:
+        """Detect whether a scenario folder uses the lossless mesh representation.
+
+        Detection is primarily based on the presence of the mesh files
+        (``faces.npz`` and ``materials.npz``). As a fallback, a local ``params.json``
+        scene block flag is consulted. Missing signals are treated as the legacy
+        hull representation, keeping backward compatibility with old scenarios.
+
+        Args:
+            base_folder: Base folder containing the scene files.
+
+        Returns:
+            bool: True if the folder uses the mesh representation.
+
+        """
+        base_path = Path(base_folder)
+        faces_path = base_path / SCENE_MESH_FACES_FILENAME
+        materials_path = base_path / SCENE_MESH_MATERIALS_FILENAME
+        if faces_path.exists() and materials_path.exists():
+            return True
+        params_path = base_path / f"{PARAMS_FILENAME}.json"
+        if params_path.exists():
+            try:
+                params = load_dict_from_json(str(params_path))
+                scene_block = params.get(SCENE_PARAM_NAME, {})
+                return scene_block.get(SCENE_PARAM_REPRESENTATION) == SCENE_REPRESENTATION_MESH
+            except Exception:  # noqa: BLE001 - never let detection break loading
+                return False
+        return False
+
+    @classmethod
+    def _from_data_mesh(cls: Any, base_folder: str) -> Scene:
+        """Reconstruct a scene from the lossless triangular-mesh files.
+
+        Args:
+            base_folder: Base folder containing the scene files.
+
+        """
+        scene = cls()
+        faces_path = f"{base_folder}/{SCENE_MESH_FACES_FILENAME}"
+        materials_path = f"{base_folder}/{SCENE_MESH_MATERIALS_FILENAME}"
+        try:
+            vertices = load_mat(f"{base_folder}/vertices.{MAT_FMT}", "vertices")
+            objects_metadata = load_dict_from_json(f"{base_folder}/objects.json")
+            with np.load(faces_path) as faces_npz:
+                faces_arrays = {key: faces_npz[key] for key in faces_npz.files}
+            with np.load(materials_path) as materials_npz:
+                materials_arrays = {key: materials_npz[key] for key in materials_npz.files}
+        except FileNotFoundError:
+            print(f"FileNotFoundError: mesh scene files not found in {base_folder}")
+            return scene
+        except Exception as e:
+            msg = f"Error loading mesh scene from {base_folder}: {e}"
+            raise RuntimeError(msg) from e
+        for object_data in objects_metadata:
+            mesh_key = object_data["mesh_key"]
+            tri_vertex_idxs = faces_arrays[mesh_key]
+            tri_material_idxs = materials_arrays[mesh_key]
+            if len(tri_vertex_idxs) == 0:
+                continue
+            obj = PhysicalElement.from_mesh_arrays(
+                object_data,
+                tri_vertex_idxs,
+                tri_material_idxs,
+                vertices,
+            )
             scene.add_object(obj)
         return scene
 
@@ -953,326 +1183,18 @@ def _get_faces_convex_hull(vertices: np.ndarray) -> list[list[tuple[float, float
     return [bottom_face, top_face, *side_faces]
 
 
-def _calculate_angle_deviation(p1: np.ndarray, p2: np.ndarray, p3: np.ndarray) -> float:
-    """Calculate the deviation from a straight line at point p2.
-
-    Returns angle in degrees, where:
-    - 0° means the path p1->p2->p3 forms a straight line
-    - 180° means the path doubles back on itself.
-    """
-    if np.allclose(p1, p2) or np.allclose(p2, p3):
-        return 180.0
-    v1 = p2 - p1
-    v2 = p3 - p2
-    v1_norm = v1 / np.linalg.norm(v1)
-    v2_norm = v2 / np.linalg.norm(v2)
-    dot_product = np.clip(np.dot(v1_norm, v2_norm), -1.0, 1.0)
-    return np.degrees(np.arccos(dot_product))
-
-
-def _ccw(a: np.ndarray, b: np.ndarray, c: np.ndarray) -> bool:
-    """Check if points are in counter-clockwise order."""
-    return (c[1] - a[1]) * (b[0] - a[0]) > (b[1] - a[1]) * (c[0] - a[0])
-
-
-def _segments_intersect(p1: np.ndarray, p2: np.ndarray, q1: np.ndarray, q2: np.ndarray) -> bool:
-    """Check if two line segments intersect."""
-    return _ccw(p1, q1, q2) != _ccw(p2, q1, q2) and _ccw(p1, p2, q1) != _ccw(p1, p2, q2)
-
-
-def _tsp_held_karp_no_intersections(points: np.ndarray) -> tuple[float, list[int]]:  # noqa: PLR0912, C901
-    """Held-Karp TSP with angle penalty + intersection check.
-
-    Returns:
-        tuple[float, list[int]]: Minimum cost and path
-
-    """
-    n = len(points)
-    cost_cache: dict[tuple[int, int], tuple[float, list[int]]] = {}
-    for k in range(1, n):
-        dist = np.linalg.norm(points[0] - points[k])
-        cost_cache[1 << k, k] = (dist, [0, k])
-    for subset_size in range(2, n):
-        for subset in itertools.combinations(range(1, n), subset_size):
-            bits = sum(1 << x for x in subset)
-            for k in subset:
-                prev_bits = bits & ~(1 << k)
-                res = []
-                for m in subset:
-                    if m == k:
-                        continue
-                    (prev_cost, prev_path) = cost_cache.get((prev_bits, m), (float("inf"), []))
-                    if not prev_path:
-                        continue
-                    new_seg = (points[m], points[k])
-                    intersects = False
-                    for i in range(len(prev_path) - 2):
-                        (a, b) = (prev_path[i], prev_path[i + 1])
-                        if _segments_intersect(points[a], points[b], new_seg[0], new_seg[1]):
-                            intersects = True
-                            break
-                    if intersects:
-                        continue
-                    if len(prev_path) > 1:
-                        angle_cost = _calculate_angle_deviation(
-                            points[prev_path[-2]],
-                            points[m],
-                            points[k],
-                        )
-                    else:
-                        angle_cost = 0
-                    cost = prev_cost + np.linalg.norm(points[m] - points[k]) + angle_cost
-                    res.append((cost, [*prev_path, k]))
-                if res:
-                    cost_cache[bits, k] = min(res)
-    bits = (1 << n) - 2
-    res = []
-    for k in range(1, n):
-        if (bits, k) not in cost_cache:
-            continue
-        (cost, path) = cost_cache[bits, k]
-        new_seg = (points[k], points[0])
-        intersects = False
-        for i in range(len(path) - 2):
-            (a, b) = (path[i], path[i + 1])
-            if _segments_intersect(points[a], points[b], new_seg[0], new_seg[1]):
-                intersects = True
-                break
-        if intersects:
-            continue
-        angle_cost = _calculate_angle_deviation(points[path[-2]], points[k], points[0])
-        final_cost = cost + np.linalg.norm(points[k] - points[0]) + angle_cost
-        res.append((final_cost, [*path, 0]))
-    return min(res) if res else (float("inf"), [])
-
-
-def _detect_endpoints(
-    points_2d: np.ndarray,
-    min_distance: float = 2.0,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Detect endpoints of a road by finding pairs of points that are furthest apart.
-
-    Points closer than min_distance are considered duplicates and only one is kept.
-
-    Args:
-        points_2d: Array of 2D points (N x 2)
-        min_distance: Minimum distance between points to consider them distinct
-
-    Returns:
-        List of endpoint indices alternating between the two detected pairs.
-
-    """
-    kept_indices = []
-    used_points = set()
-    for i in range(len(points_2d)):
-        if i in used_points:
-            continue
-        distances = np.linalg.norm(points_2d - points_2d[i], axis=1)
-        close_points = np.where(distances < min_distance)[0]
-        used_points.update(close_points)
-        kept_indices.append(i)
-    filtered_points = points_2d[kept_indices]
-    distances = np.linalg.norm(filtered_points[:, np.newaxis] - filtered_points, axis=2)
-    (i1, j1) = np.unravel_index(np.argmax(distances), distances.shape)
-    distances_masked = distances.copy()
-    distances_masked[i1, :] = -np.inf
-    distances_masked[:, i1] = -np.inf
-    distances_masked[j1, :] = -np.inf
-    distances_masked[:, j1] = -np.inf
-    (i2, j2) = np.unravel_index(np.argmax(distances_masked), distances_masked.shape)
-    return [kept_indices[i] for i in [i1, i2, j1, j2]]
-
-
-def _signed_distance_to_curve(
-    point: np.ndarray,
-    curve_fit: np.poly1d,
-    x_range: tuple[float, float],
-) -> tuple[float, np.ndarray]:
-    """Calculate signed perpendicular distance from point to curve.
-
-    Positive distance means point is on one side, negative on the other.
-
-    Args:
-        point: Point to calculate distance to
-        curve_fit: Polynomial fit to the curve
-        x_range: Range of x-values for the curve
-
-    Returns:
-        tuple[float, np.ndarray]: Signed distance and closest point on curve
-
-    """
-    curve_x = np.linspace(x_range[0], x_range[1], 1000)
-    curve_y = curve_fit(curve_x)
-    curve_points = np.column_stack((curve_x, curve_y))
-    distances = np.linalg.norm(curve_points - point, axis=1)
-    closest_idx = np.argmin(distances)
-    closest_point = curve_points[closest_idx]
-    if closest_idx < len(curve_x) - 1:
-        tangent = curve_points[closest_idx + 1] - curve_points[closest_idx]
-    else:
-        tangent = curve_points[closest_idx] - curve_points[closest_idx - 1]
-    tangent = tangent / np.linalg.norm(tangent)
-    normal = np.array([-tangent[1], tangent[0]])
-    vec_to_point = point - closest_point
-    signed_dist = np.dot(vec_to_point, normal)
-    return (signed_dist, closest_point)
-
-
-def _trim_points_protected(
-    points: np.ndarray,
-    protected_indices: list[int],
-    max_points: int = 14,
-) -> list[int]:
-    """Trims points while preserving protected indices and maintaining road shape.
-
-    Uses reference points along the curve to select closest points above and below.
-    Assumes endpoints are included in protected_indices.
-
-    Args:
-        points: Array of point coordinates (N x 2)
-        protected_indices: List of indices that should not be removed
-        max_points: Maximum number of points to keep
-        debug: Whether to show debug plots
-
-    Returns:
-        List of indices of the kept points
-
-    """
-    protected_indices = set(protected_indices)
-    if max_points < len(protected_indices):
-        msg = "max_points must be >= number of protected points"
-        raise ValueError(msg)
-    if len(points) < len(protected_indices):
-        msg = "len(points) must be >= max_points"
-        raise ValueError(msg)
-    x = points[:, 0]
-    y = points[:, 1]
-    z = np.polyfit(x, y, 3)
-    curve_fit = np.poly1d(z)
-    x_range = (x.min(), x.max())
-    distances_and_closest = [
-        _signed_distance_to_curve(points[i], curve_fit, x_range) for i in range(len(points))
-    ]
-    distances = np.array([d for (d, _) in distances_and_closest])
-    ref_positions = [0.25, 0.5, 0.75]
-    x_refs = x_range[0] + (x_range[1] - x_range[0]) * np.array(ref_positions)
-    ref_points = np.column_stack((x_refs, curve_fit(x_refs)))
-    kept_indices = set(protected_indices)
-    for ref_point in ref_points:
-        dists_to_ref = np.linalg.norm(points - ref_point, axis=1)
-        above_curve = distances > 0
-        below_curve = distances < 0
-        above_indices = [
-            i for i in range(len(points)) if above_curve[i] and i not in protected_indices
-        ]
-        below_indices = [
-            i for i in range(len(points)) if below_curve[i] and i not in protected_indices
-        ]
-        above_indices = sorted(above_indices, key=lambda i: dists_to_ref[i])
-        below_indices = sorted(below_indices, key=lambda i: dists_to_ref[i])
-        for idx in above_indices:
-            if idx not in kept_indices:
-                kept_indices.add(idx)
-                break
-        for idx in below_indices:
-            if idx not in kept_indices:
-                kept_indices.add(idx)
-                break
-    return sorted(kept_indices)
-
-
-def _compress_path(points: np.ndarray, path: list[int], angle_threshold: float = 1.0) -> list[int]:
-    """Compress a path by removing points that are nearly collinear with their neighbors.
-
-    Args:
-        points: Array of point coordinates (N x 2)
-        path: List of indices forming the path
-        angle_threshold: Minimum angle deviation (in degrees) to keep a point
-
-    Returns:
-        List of indices forming the compressed path
-
-    """
-    min_path_len = 3
-    if len(path) <= min_path_len:
-        return path
-    compressed = [path[0]]
-    for i in range(1, len(path) - 1):
-        prev_idx = compressed[-1]
-        curr_idx = path[i]
-        next_idx = path[i + 1]
-        angle = _calculate_angle_deviation(points[prev_idx], points[curr_idx], points[next_idx])
-        if angle > angle_threshold:
-            compressed.append(curr_idx)
-    compressed.append(path[-1])
-    return compressed
-
-
-def _get_2d_face(
-    vertices: np.ndarray,
-    z_tolerance: float = 0.1,
-    max_points: int = 10,
-    *,
-    compress: bool = True,
-    angle_threshold: float = 1.0,
-) -> list[tuple[float, float, float]]:
-    """Generate a 2D face from a set of vertices.
-
-    Args:
-        vertices: Array of vertex coordinates (shape: N x 3)
-        z_tolerance: Tolerance for z-coordinate variation - targetted for roads
-        max_points: Maximum number of points to consider
-        compress: Whether to compress the final path
-        angle_threshold: Angle threshold for collinearity
-
-    Returns:
-        List of (x,y,z) vertex coordinates for the face
-
-    """
-    if not np.allclose(vertices[:, 2], vertices[0, 2], atol=z_tolerance):
-        msg = "Vertices are not 2D"
-        raise ValueError(msg)
-    endpoints = _detect_endpoints(vertices[:, :2])
-    kept_indices = _trim_points_protected(
-        vertices[:, :2],
-        protected_indices=endpoints,
-        max_points=max_points,
-    )
-    points_filtered = vertices[kept_indices]
-    (_, best_path) = _tsp_held_karp_no_intersections(points_filtered[:, :2])
-    if compress:
-        compressed_path = _compress_path(
-            points_filtered,
-            best_path,
-            angle_threshold=angle_threshold,
-        )
-        final_points = points_filtered[compressed_path[:-1]]
-    else:
-        final_points = points_filtered[best_path[:-1]]
-    return [final_points]
-
-
 def get_object_faces(
     vertices: list[tuple[float, float, float]],
-    *,
-    fast: bool = True,
 ) -> list[list[tuple[float, float, float]]]:
     """Generate faces for a physical object from its vertices.
 
-    This function supports two modes:
-    1. Fast mode (default):
-       - Uses convex hull to create a simplified geometric shape
-       - Creates top, bottom and side faces
-       - More efficient but loses geometric detail
-
-    2. Detailed mode:
-       - Detects coplanar sets of vertices to form faces
-       - Preserves original geometry
-       - Slower but more accurate
+    Uses a convex-hull approach to create a simplified geometric shape with top,
+    bottom and side faces. This is efficient but loses geometric detail. To retain
+    the exact triangular geometry, export the scene with the lossless mesh
+    representation (see ``Scene.export_data(..., lossless=True)``).
 
     Args:
         vertices: List of (x,y,z) vertex coordinates for the object
-        fast: Whether to use fast convex-hull mode or detailed coplanar detection
 
     Returns:
         List of faces, where each face is a list of (x,y,z) vertex coordinates
@@ -1282,26 +1204,4 @@ def get_object_faces(
     vertices = np.array(vertices)
     if len(vertices) < min_vertices_for_face:
         return None
-    return _get_faces_convex_hull(vertices) if fast else _get_2d_face(vertices)
-
-
-if __name__ == "__main__":
-    points = np.array([[0, 0], [1, 0], [1, 1], [0, 1]])
-    path = [0, 1, 2, 3]
-    compressed = _compress_path(points, path)
-    print(compressed)
-
-    def plot_points(points: np.ndarray, path: list[int] | None = None, title: str = "") -> None:
-        """Visualize a set of points and optionally connect them."""
-        plt.figure(figsize=(8, 6))
-        plt.scatter(points[:, 0], points[:, 1], color="blue")
-        for i, (x, y) in enumerate(points):
-            plt.text(x + 1, y + 1, str(i), fontsize=9)
-        if path:
-            for i in range(len(path) - 1):
-                (p1, p2) = (points[path[i]], points[path[i + 1]])
-                plt.plot([p1[0], p2[0]], [p1[1], p2[1]], "r-")
-        plt.title(title)
-        plt.axis("equal")
-        plt.grid(visible=True)
-        plt.show()
+    return _get_faces_convex_hull(vertices)

--- a/deepmimo/datasets/dataset.py
+++ b/deepmimo/datasets/dataset.py
@@ -80,6 +80,163 @@ SHARED_PARAMS = [
     c.RT_PARAMS_PARAM_NAME,
 ]
 
+# Memory budget (number of (point, triangle) pairs) per vectorized chunk used
+# when assigning interaction points to the nearest triangular face in lossless
+# mesh scenes. Caps the transient [chunk, n_triangles, 3] arrays regardless of
+# how many interaction points / triangles the scene contains.
+_POINT_TRIANGLE_PAIR_BUDGET = 4_000_000
+
+
+def _gather_object_triangles(
+    objects: list,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Collect every triangular face of ``objects`` into flat vertex arrays.
+
+    Args:
+        objects: Physical elements whose triangular faces should be gathered.
+
+    Returns:
+        tuple of (v0, v1, v2, tri_obj_ids):
+            - v0, v1, v2: ``(T, 3)`` float arrays holding the three vertices of
+              each of the ``T`` triangles.
+            - tri_obj_ids: ``(T,)`` int array mapping each triangle to the
+              ``object_id`` of the element that owns it.
+
+    """
+    tris_per_obj: list[np.ndarray] = []
+    obj_ids_per_obj: list[np.ndarray] = []
+    for obj in objects:
+        obj_tris = [tri for face in obj.faces for tri in face.triangular_faces]
+        if not obj_tris:
+            continue
+        obj_tris_arr = np.asarray(obj_tris, dtype=float)  # (t, 3, 3)
+        tris_per_obj.append(obj_tris_arr)
+        obj_ids_per_obj.append(np.full(len(obj_tris_arr), obj.object_id, dtype=int))
+    if not tris_per_obj:
+        empty = np.zeros((0, 3), dtype=float)
+        return empty, empty, empty, np.zeros((0,), dtype=int)
+    tris = np.concatenate(tris_per_obj, axis=0)  # (T, 3, 3)
+    tri_obj_ids = np.concatenate(obj_ids_per_obj)  # (T,)
+    return tris[:, 0, :], tris[:, 1, :], tris[:, 2, :], tri_obj_ids
+
+
+def _point_segment_distances(points: np.ndarray, a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Distance from each point to each segment ``[a, b]`` (vectorized).
+
+    Args:
+        points: ``(P, 3)`` query points.
+        a: ``(T, 3)`` segment start vertices.
+        b: ``(T, 3)`` segment end vertices.
+
+    Returns:
+        ``(P, T)`` array of point-to-segment distances.
+
+    """
+    ab = b - a  # (T, 3)
+    ab_len2 = np.einsum("tj,tj->t", ab, ab)  # (T,)
+    safe_len2 = np.where(ab_len2 > 0.0, ab_len2, 1.0)
+    ap = points[:, None, :] - a[None, :, :]  # (P, T, 3)
+    t = np.einsum("ptj,tj->pt", ap, ab) / safe_len2  # (P, T)
+    t = np.clip(t, 0.0, 1.0)
+    closest = a[None, :, :] + t[:, :, None] * ab[None, :, :]  # (P, T, 3)
+    return np.linalg.norm(points[:, None, :] - closest, axis=2)  # (P, T)
+
+
+def _point_triangle_distances(
+    points: np.ndarray, v0: np.ndarray, v1: np.ndarray, v2: np.ndarray
+) -> np.ndarray:
+    """Exact Euclidean distance from each point to each triangle (vectorized).
+
+    The closest point of a triangle to an external query point is either the
+    orthogonal projection onto the triangle plane (when that projection lands
+    inside the triangle) or a point on one of its three edges. Both candidates
+    are computed and selected per (point, triangle) pair, yielding the exact
+    point-to-triangle distance (not an approximation).
+
+    Args:
+        points: ``(P, 3)`` query points.
+        v0: ``(T, 3)`` first triangle vertices.
+        v1: ``(T, 3)`` second triangle vertices.
+        v2: ``(T, 3)`` third triangle vertices.
+
+    Returns:
+        ``(P, T)`` array of exact point-to-triangle distances.
+
+    """
+    eps = 1e-12
+    ab = v1 - v0  # (T, 3)
+    ac = v2 - v0  # (T, 3)
+    d00 = np.einsum("tj,tj->t", ab, ab)  # (T,)
+    d01 = np.einsum("tj,tj->t", ab, ac)  # (T,)
+    d11 = np.einsum("tj,tj->t", ac, ac)  # (T,)
+    denom = d00 * d11 - d01 * d01  # (T,)
+    non_degenerate = np.abs(denom) > eps  # (T,)
+    safe_denom = np.where(non_degenerate, denom, 1.0)
+
+    ap = points[:, None, :] - v0[None, :, :]  # (P, T, 3)
+    d20 = np.einsum("ptj,tj->pt", ap, ab)  # (P, T)
+    d21 = np.einsum("ptj,tj->pt", ap, ac)  # (P, T)
+    # Barycentric coordinates of the in-plane projection of each point.
+    bary_v = (d11 * d20 - d01 * d21) / safe_denom  # (P, T)
+    bary_w = (d00 * d21 - d01 * d20) / safe_denom  # (P, T)
+    bary_u = 1.0 - bary_v - bary_w  # (P, T)
+    inside = (bary_u >= 0) & (bary_v >= 0) & (bary_w >= 0) & non_degenerate[None, :]
+
+    normal = np.cross(ab, ac)  # (T, 3)
+    normal_len = np.linalg.norm(normal, axis=1)  # (T,)
+    safe_normal_len = np.where(normal_len > eps, normal_len, 1.0)
+    unit_normal = normal / safe_normal_len[:, None]  # (T, 3)
+    dist_plane = np.abs(np.einsum("ptj,tj->pt", ap, unit_normal))  # (P, T)
+
+    edge_dist = np.minimum(
+        np.minimum(
+            _point_segment_distances(points, v0, v1),
+            _point_segment_distances(points, v1, v2),
+        ),
+        _point_segment_distances(points, v2, v0),
+    )  # (P, T)
+    return np.where(inside, dist_plane, edge_dist)
+
+
+def _nearest_triangle_object_ids(  # noqa: PLR0913
+    points: np.ndarray,
+    v0: np.ndarray,
+    v1: np.ndarray,
+    v2: np.ndarray,
+    tri_obj_ids: np.ndarray,
+    pair_budget: int = _POINT_TRIANGLE_PAIR_BUDGET,
+) -> np.ndarray:
+    """Assign each point to the ``object_id`` owning its nearest triangle.
+
+    Uses the exact point-to-triangle distance. Points are processed in chunks so
+    the transient ``(chunk, T, 3)`` arrays stay within ``pair_budget`` (point,
+    triangle) pairs, bounding peak memory regardless of scene size. The cost is
+    ``O(P x T)`` (interaction points x triangles): when both are large this is
+    heavier than the hull bbox-center heuristic, which is the deliberate
+    accuracy-vs-throughput trade-off of using the lossless mesh.
+
+    Args:
+        points: ``(P, 3)`` query points.
+        v0: ``(T, 3)`` first triangle vertices.
+        v1: ``(T, 3)`` second triangle vertices.
+        v2: ``(T, 3)`` third triangle vertices.
+        tri_obj_ids: ``(T,)`` owning object_id per triangle.
+        pair_budget: Maximum number of (point, triangle) pairs per chunk.
+
+    Returns:
+        ``(P,)`` int array with the owning object_id for each point.
+
+    """
+    n_points = len(points)
+    result = np.empty(n_points, dtype=tri_obj_ids.dtype)
+    n_tris = len(tri_obj_ids)
+    chunk = max(1, pair_budget // max(1, n_tris))
+    for start in range(0, n_points, chunk):
+        stop = start + chunk
+        dists = _point_triangle_distances(points[start:stop], v0, v1, v2)  # (c, T)
+        result[start:stop] = tri_obj_ids[np.argmin(dists, axis=1)]
+    return result
+
 
 class Dataset(DotDict):
     """Class for managing DeepMIMO datasets.
@@ -1665,6 +1822,20 @@ class Dataset(DotDict):
         Each object represents the object that the path interacts with.
         The objects are returned as the object index.
 
+        Assignment of a (non-terrain) interaction point to an object depends on
+        the loaded scene's geometry representation:
+
+        - Hull/legacy scenes (``scene.representation == "hull"``): the point is
+          assigned to the non-terrain object whose bounding-box *center* is
+          nearest. This is the long-standing heuristic and is left unchanged.
+        - Lossless mesh scenes (``scene.representation == "mesh"``): the point is
+          assigned to the object owning the nearest *triangular face* using the
+          exact point-to-triangle distance, which is substantially more accurate
+          than bounding-box centers (see ``_compute_inter_objects_mesh``).
+
+        The terrain z-snap behavior (assigning the terrain object when a point's
+        z is approximately the terrain top) is identical in both modes.
+
         Returns:
             np.ndarray: The objects that interact with each path of each user.
             Shape: [n_ue, max_paths, max_interactions]
@@ -1678,6 +1849,13 @@ class Dataset(DotDict):
         terrain_obj = terrain_objs[0]
         terrain_z_coord = terrain_obj.bounding_box.z_max
         non_terrain_objs = [obj for obj in self.scene.objects if obj.label != "terrain"]
+        scene_repr = getattr(
+            self.scene, c.SCENE_PARAM_REPRESENTATION, c.SCENE_REPRESENTATION_HULL
+        )
+        if scene_repr == c.SCENE_REPRESENTATION_MESH:
+            return self._compute_inter_objects_mesh(
+                inter_obj_ids, terrain_obj, terrain_z_coord, non_terrain_objs
+            )
         obj_centers = np.array([obj.bounding_box.center for obj in non_terrain_objs])
         obj_ids = np.array([obj.object_id for obj in non_terrain_objs])
         for ue_i in tqdm(range(self.n_ue), desc="Computing interaction objects per UE"):
@@ -1693,6 +1871,59 @@ class Dataset(DotDict):
                     dist = np.linalg.norm(obj_centers - i_pos, axis=1)
                     obj_idx = np.argmin(dist)
                     inter_obj_ids[ue_i, path_i, i] = obj_ids[obj_idx]
+        return inter_obj_ids
+
+    def _compute_inter_objects_mesh(
+        self,
+        inter_obj_ids: np.ndarray,
+        terrain_obj: Any,
+        terrain_z_coord: float,
+        non_terrain_objs: list,
+    ) -> np.ndarray:
+        """Mesh-scene variant of :meth:`_compute_inter_objects`.
+
+        Each non-terrain interaction point is assigned to the object owning the
+        nearest *triangular face* using the exact point-to-triangle distance,
+        which is far more accurate than the hull bounding-box-center heuristic
+        when the lossless mesh geometry is available. Terrain points are still
+        resolved by the same z-snap test as the hull path.
+
+        The terrain z-snap loop mirrors the hull path so terrain assignment is
+        byte-identical; non-terrain points are gathered and assigned in a single
+        vectorized (chunked) pass over all triangular faces.
+
+        Args:
+            inter_obj_ids: Pre-allocated ``(n_ue, max_paths, max_inter)`` array
+                of NaNs to fill in place.
+            terrain_obj: The single terrain object (z-snap target).
+            terrain_z_coord: Terrain top z used for the z-snap test.
+            non_terrain_objs: Objects eligible for nearest-face assignment.
+
+        Returns:
+            np.ndarray: The filled ``inter_obj_ids`` array.
+
+        """
+        v0, v1, v2, tri_obj_ids = _gather_object_triangles(non_terrain_objs)
+        pending_points: list[np.ndarray] = []
+        pending_idx: list[tuple[int, int, int]] = []
+        for ue_i in tqdm(range(self.n_ue), desc="Computing interaction objects per UE"):
+            for path_i in range(self.max_paths):
+                n_inter = self.num_interactions[ue_i, path_i]
+                if np.isnan(n_inter) or n_inter == 0:
+                    continue
+                for i in range(int(n_inter)):
+                    i_pos = self.inter_pos[ue_i, path_i, i]
+                    if np.isclose(i_pos[2], terrain_z_coord, rtol=0, atol=0.001):
+                        inter_obj_ids[ue_i, path_i, i] = terrain_obj.object_id
+                        continue
+                    pending_points.append(i_pos)
+                    pending_idx.append((ue_i, path_i, i))
+        if pending_points and len(tri_obj_ids) > 0:
+            nearest = _nearest_triangle_object_ids(
+                np.asarray(pending_points, dtype=float), v0, v1, v2, tri_obj_ids
+            )
+            for (ue_i, path_i, i), obj_id in zip(pending_idx, nearest, strict=True):
+                inter_obj_ids[ue_i, path_i, i] = obj_id
         return inter_obj_ids
 
     def clear_all_caches(self) -> None:

--- a/deepmimo/pipelines/blender_osm.py
+++ b/deepmimo/pipelines/blender_osm.py
@@ -16,10 +16,8 @@ from .utils.blender_utils import (
     create_ground_plane,
     export_mesh_obj_to_ply,
     export_mitsuba_scene,
-    get_xy_bounds_from_latlon,
     install_blender_addon,
     log_local_setup,
-    process_roads,
     save_bbox_metadata,
     save_osm_origin,
     set_logger,
@@ -89,13 +87,10 @@ def fetch_osm_scene(  # noqa: PLR0913 - signature follows Blender/OSM requiremen
     setup_world_lighting()
 
     building_material_name = "itu_concrete"
-    road_material_name = "itu_brick"
 
     # Create materials (for lighting/coloring and downstream processing)
     building_material = bpy.data.materials.new(name=building_material_name)
     building_material.diffuse_color = (0.75, 0.40, 0.16, 1)  # Beige
-    road_material = bpy.data.materials.new(name=road_material_name)
-    road_material.diffuse_color = (0.29, 0.25, 0.21, 1)  # Dark grey
 
     # Convert all to meshes
     convert_objects_to_mesh()
@@ -107,10 +102,6 @@ def fetch_osm_scene(  # noqa: PLR0913 - signature follows Blender/OSM requiremen
     # Process buildings
     add_materials_to_objs("building", building_material)
 
-    # Process roads
-    terrain_bounds = get_xy_bounds_from_latlon(minlat, minlon, maxlat, maxlon, pad=40)
-    process_roads(terrain_bounds, road_material)  # Filter, trim to bounds and add material
-
     # Render processed scene
     create_camera_and_render(im_path.replace(".png", "_processed.png"))
 
@@ -118,9 +109,8 @@ def fetch_osm_scene(  # noqa: PLR0913 - signature follows Blender/OSM requiremen
     if "insite" in output_formats:
         logger.info("🔄 Outputting InSite scene...")
 
-        # Export buildings and roads
+        # Export buildings
         export_mesh_obj_to_ply("building", output_folder)
-        export_mesh_obj_to_ply("road", output_folder)
 
         logger.info("✅ InSite scene exported.")
 

--- a/deepmimo/pipelines/utils/blender_utils.py
+++ b/deepmimo/pipelines/utils/blender_utils.py
@@ -13,7 +13,6 @@ from typing import Any
 
 # Blender imports
 import bpy  # type: ignore[import]
-import mathutils  # type: ignore[import] (comes with blender)
 import requests
 
 ADDONS = {
@@ -363,23 +362,6 @@ def create_camera_and_render(
 # SCENE PROCESSING UTILITIES
 ###############################################################################
 
-REJECTED_ROAD_KEYWORDS = ["profile_", "paths_steps"]
-
-TIERS = {
-    1: [
-        "map.osm_roads_primary",
-        "map.osm_roads_residential",
-        "map.osm_roads_tertiary",
-        "map.osm_roads_secondary",
-        "map.osm_roads_unclassified",
-        "map.osm_roads_service",
-    ],
-    2: ["map.osm_paths_footway"],
-}
-
-# Reject all roads because of sionna 1.1 material bug
-REJECTED_ROAD_KEYWORDS += TIERS[1] + TIERS[2]
-
 
 def create_ground_plane(
     min_lat: float,
@@ -439,114 +421,6 @@ def add_materials_to_objs(
         return obj
 
 
-def trim_faces_outside_bounds(
-    obj: bpy.types.Object,
-    min_x: float,
-    max_x: float,
-    min_y: float,
-    max_y: float,
-) -> None:
-    """Trim faces at bounds and remove exterior parts via boolean intersection."""
-    LOGGER.info("✂️ Trimming faces at bounds for object: %s", obj.name)
-    try:
-        # First check if object is completely outside bounds
-        bbox_corners = [obj.matrix_world @ mathutils.Vector(corner) for corner in obj.bound_box]
-        obj_min_x = min(corner.x for corner in bbox_corners)
-        obj_max_x = max(corner.x for corner in bbox_corners)
-        obj_min_y = min(corner.y for corner in bbox_corners)
-        obj_max_y = max(corner.y for corner in bbox_corners)
-
-        LOGGER.debug(
-            "Object bounds: x=[%.2f, %.2f], y=[%.2f, %.2f]",
-            obj_min_x,
-            obj_max_x,
-            obj_min_y,
-            obj_max_y,
-        )
-        LOGGER.debug(
-            "Target bounds: x=[%.2f, %.2f], y=[%.2f, %.2f]",
-            min_x,
-            max_x,
-            min_y,
-            max_y,
-        )
-
-        # Expand the bounds by a factor to keep more of the roads
-        expansion_factor = 2.0  # Double the bounds to better match road sizes
-        expanded_min_x = min_x * expansion_factor
-        expanded_max_x = max_x * expansion_factor
-        expanded_min_y = min_y * expansion_factor
-        expanded_max_y = max_y * expansion_factor
-
-        LOGGER.debug(
-            "Expanded bounds: x=[%.2f, %.2f], y=[%.2f, %.2f]",
-            expanded_min_x,
-            expanded_max_x,
-            expanded_min_y,
-            expanded_max_y,
-        )
-
-        # If object is completely outside expanded bounds, delete it
-        if (
-            obj_max_x < expanded_min_x
-            or obj_min_x > expanded_max_x
-            or obj_max_y < expanded_min_y
-            or obj_min_y > expanded_max_y
-        ):
-            LOGGER.warning(
-                "Object %s is completely outside expanded bounds - skipping",
-                obj.name,
-            )
-            return
-
-        # If object is completely inside original bounds, keep it
-        if obj_min_x >= min_x and obj_max_x <= max_x and obj_min_y >= min_y and obj_max_y <= max_y:
-            LOGGER.info(
-                "Object %s is completely inside bounds - keeping as is",
-                obj.name,
-            )
-            return
-
-        LOGGER.info("Initial face count for %s: %d", obj.name, len(obj.data.polygons))
-
-        # Create a cube that will be our bounding box
-        padding = 0.1  # Small padding to avoid precision issues
-        bpy.ops.mesh.primitive_cube_add(size=1)
-        bound_box = bpy.context.active_object
-
-        # Scale and position the bounding box using expanded bounds
-        width = (expanded_max_x - expanded_min_x) + 2 * padding
-        height = (expanded_max_y - expanded_min_y) + 2 * padding
-        depth = 1000  # Make it very tall to ensure it intersects the full height
-
-        bound_box.scale = (width / 2, height / 2, depth / 2)
-        bound_box.location = (
-            (expanded_max_x + expanded_min_x) / 2,
-            (expanded_max_y + expanded_min_y) / 2,
-            0,
-        )
-
-        # Add boolean modifier to the original object
-        bool_mod = obj.modifiers.new(name="Boolean", type="BOOLEAN")
-        bool_mod.object = bound_box
-        bool_mod.operation = "INTERSECT"
-
-        # Apply the boolean modifier
-        LOGGER.debug("Applying boolean intersection")
-        bpy.context.view_layer.objects.active = obj
-        bpy.ops.object.modifier_apply(modifier=bool_mod.name)
-
-        # Delete the bounding box
-        bpy.data.objects.remove(bound_box, do_unlink=True)
-
-        LOGGER.info("Final face count for %s: %d", obj.name, len(obj.data.polygons))
-
-    except Exception as e:
-        error_msg = f"❌ Failed to trim faces for {obj.name}: {e!s}"
-        LOGGER.exception(error_msg)
-        raise RuntimeError(error_msg) from e
-
-
 def convert_objects_to_mesh() -> None:
     """Convert all selected objects to mesh type."""
     LOGGER.info("🔄 Converting objects to mesh")
@@ -562,57 +436,6 @@ def convert_objects_to_mesh() -> None:
         error_msg = f"❌ Failed to convert objects to mesh: {e!s}"
         LOGGER.exception(error_msg)
         raise RuntimeError(error_msg) from e
-
-
-def process_roads(  # noqa: C901
-    terrain_bounds: tuple[float, float, float, float],
-    road_material: bpy.types.Material,
-) -> None:
-    """Process roads using tiered priority and material assignment.
-
-    Args:
-        terrain_bounds: (min_x, max_x, min_y, max_y) in meters
-        road_material: Material to apply to selected roads
-
-    """
-    LOGGER.info("🛣️ Starting road processing")
-
-    # Step 1: Delete rejected roads early
-    for obj in list(bpy.data.objects):
-        if any(k in obj.name.lower() for k in REJECTED_ROAD_KEYWORDS):
-            LOGGER.debug("❌ Rejecting road: %s", obj.name)
-            bpy.data.objects.remove(obj, do_unlink=True)
-
-    # Step 2: Tiered selection
-    selected_roads = []
-    for tier, names in TIERS.items():
-        objs = [obj for name in names if (obj := bpy.data.objects.get(name))]
-        if objs:
-            selected_roads = objs
-            selected_tier = tier
-            LOGGER.info("✅ Using Tier %s roads", tier)
-            break
-
-    if not selected_roads:
-        LOGGER.warning("⚠️ No valid road objects found in any tier")
-        return
-
-    # Step 3: Remove roads from lower tiers
-    for tier, names in TIERS.items():
-        if tier <= selected_tier:
-            continue
-        for name in names:
-            obj = bpy.data.objects.get(name)
-            if obj:
-                LOGGER.debug("🗑️ Removing tier %s road: %s", tier, obj.name)
-                bpy.data.objects.remove(obj, do_unlink=True)
-
-    # Step 4: Process selected roads
-    for obj in selected_roads:
-        LOGGER.info("🔄 Processing road: %s", obj.name)
-        trim_faces_outside_bounds(obj, *terrain_bounds)
-        obj.data.materials.clear()
-        obj.data.materials.append(road_material)
 
 
 ###############################################################################

--- a/deepmimo/pipelines/wireless_insite/insite_raytracer.py
+++ b/deepmimo/pipelines/wireless_insite/insite_raytracer.py
@@ -4,7 +4,7 @@ This module provides functionality for running electromagnetic simulations using
 It handles:
 - Setting up the simulation environment from OpenStreetMap data:
     - Configuring transmitter and receiver positions
-    - Generating terrain, building and road models
+    - Generating terrain and building models
     - Creating simulation configuration files (.setup, .txrx, .ter, .city)
 - Running the ray tracing simulation
 
@@ -93,7 +93,6 @@ def raytrace_insite(
                 - wi_exe (str): Path to Wireless InSite executable
                 - wi_lic (str): Path to Wireless InSite license
                 - building_material (str): Path to building material file
-                - road_material (str): Path to road material file
                 - terrain_material (str): Path to terrain material file
 
             Required Parameters:
@@ -123,15 +122,12 @@ def raytrace_insite(
     """
     insite_path, study_area_path = create_directory_structure(osm_folder, rt_params)
 
-    # Create buildings.city & roads.city files
+    # Create buildings.city file
     bldgs_city = convert_to_city_file(
         osm_folder,
         insite_path,
         "buildings",
         rt_params["building_material"],
-    )
-    roads_city = (
-        None  # convert_to_city_file(osm_folder, insite_path, "roads", rt_params['road_material'])
     )
 
     xmin_pad, ymin_pad, xmax_pad, ymax_pad = convert_GpsBBox2CartesianBBox(
@@ -222,8 +218,6 @@ def raytrace_insite(
     else:
         msg = "No buildings found. Check Blender Export to ply."
         raise RuntimeError(msg)
-    if roads_city:
-        scenario.add_feature(roads_city, "road")
     scenario.save("insite")  # insite.setup
 
     # Generate XML file (.xml) - What Wireless InSite executable actually uses

--- a/docs/resources/capabilities/core.md
+++ b/docs/resources/capabilities/core.md
@@ -110,8 +110,8 @@ Represents a single face (polygon) of a physical object.
 | Vertex access | ✓ | Indexed/iterable |
 | | | |
 | **Utilities** | | |
-| Convex hull generation | ✓ | `get_object_faces()` with `fast=True` |
-| Triangle mesh support | ✓ | `get_object_faces()` with `fast=False` |
+| Convex hull generation | ✓ | `get_object_faces()` (convex-hull simplification, default) |
+| Triangle mesh support | ✓ | Lossless triangular mesh via `Scene.export_data(lossless=True)` |
 
 ### BoundingBox
 

--- a/docs/resources/specs.md
+++ b/docs/resources/specs.md
@@ -65,8 +65,24 @@ The dimensions are:
 
 | File Name | Description |
 |-----------|-------------|
-| objects.json | Contains scene object metadata including: name, label, id, face_vertex_idxs (indices into vertices.mat), face_material_idxs (indices of the materials in each face) |
-| params.json | Ray tracing parameters including: raytracer info, frequency, max_path_depth, interaction settings (reflections, diffractions, scattering, transmissions), ray casting settings, GPS bounding box, materials, and many raw parameters from the ray tracer that should be sufficient to reproduce the simulation. |
+| objects.json | Contains scene object metadata. Layout depends on the scene representation (see [Scene Geometry](#scene-geometry)). For the default `hull` representation: name, label, id, face_vertex_idxs (indices into vertices.npz), face_material_idxs (material index per face). |
+| params.json | Ray tracing parameters including: raytracer info, frequency, max_path_depth, interaction settings (reflections, diffractions, scattering, transmissions), ray casting settings, GPS bounding box, materials, and many raw parameters from the ray tracer that should be sufficient to reproduce the simulation. The `scene` block also holds `num_scenes`, `n_objects`, `n_vertices`, `n_faces`, `n_triangular_faces`, and `representation` (`hull` or `mesh`). |
+
+### Scene Geometry
+
+The physical scene geometry is stored at the scenario root as a global, deduplicated vertex pool plus per-object face metadata. Two representations are supported; the active one is recorded in the `params.json` scene block via the `representation` field:
+
+- **`hull`** (default, legacy) — compact convex-hull simplification:
+  - `vertices.npz` — global vertex pool, `N_vertices × 3` float32 (`np.savez_compressed`, key `vertices`).
+  - `objects.json` — list of per-object dicts: `name`, `label`, `id`, `face_vertex_idxs` (indices into `vertices.npz`), `face_material_idxs` (material index per face).
+
+- **`mesh`** (optional, lossless) — preserves the exact triangular geometry. Produced by `Scene.export_data(..., lossless=True)` or by passing `lossless=True` to a converter:
+  - `vertices.npz` — global vertex pool (same format as above).
+  - `faces.npz` — one int32 array per object (key = `mesh_key`), each `N_triangles × 3` vertex indices into `vertices.npz`.
+  - `materials.npz` — one int32 array per object (key = `mesh_key`), each `N_triangles` material indices.
+  - `objects.json` — list of per-object dicts: `name`, `label`, `id`, `mesh_key` (the key into `faces.npz`/`materials.npz`).
+
+Loading is backward compatible: scenarios without a `representation` field (and without mesh files) are read as `hull`. Detection is based on the presence of `faces.npz`/`materials.npz`, falling back to the `params.json` flag.
 
 ### Secondary (Computed) Matrices
 

--- a/tests/core/test_scene.py
+++ b/tests/core/test_scene.py
@@ -1,11 +1,18 @@
 """Tests for DeepMIMO Scene module."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 from scipy.spatial import ConvexHull
 
+from deepmimo.consts import (
+    SCENE_PARAM_N_TRIANGULAR_FACES,
+    SCENE_PARAM_REPRESENTATION,
+    SCENE_REPRESENTATION_HULL,
+    SCENE_REPRESENTATION_MESH,
+)
 from deepmimo.core.scene import (
     CAT_BUILDINGS,
     CAT_OBJECTS,
@@ -15,15 +22,10 @@ from deepmimo.core.scene import (
     PhysicalElement,
     PhysicalElementGroup,
     Scene,
-    _calculate_angle_deviation,
-    _ccw,
-    _detect_endpoints,
     _get_faces_convex_hull,
-    _segments_intersect,
-    _signed_distance_to_curve,
-    _tsp_held_karp_no_intersections,
     get_object_faces,
 )
+from deepmimo.utils import save_dict_as_json
 
 
 # --- BoundingBox Tests ---
@@ -151,6 +153,104 @@ def test_scene_export_import(tmp_path) -> None:
     np.testing.assert_array_almost_equal(scene2.objects[0].faces[0].vertices, obj.faces[0].vertices)
 
 
+def test_scene_export_default_is_hull(tmp_path) -> None:
+    """Default export stays the convex-hull representation (same files + flag)."""
+    obj = PhysicalElement([Face([[0, 0, 0], [1, 0, 0], [0, 1, 0]])], name="Tri", label=CAT_OBJECTS)
+    scene = Scene()
+    scene.add_object(obj)
+
+    base_folder = str(tmp_path / "scene_hull")
+    metadata = scene.export_data(base_folder)
+
+    # Representation flag is "hull" and only the legacy files are written
+    assert metadata[SCENE_PARAM_REPRESENTATION] == SCENE_REPRESENTATION_HULL
+    folder = Path(base_folder)
+    assert (folder / "vertices.npz").exists()
+    assert (folder / "objects.json").exists()
+    assert not (folder / "faces.npz").exists()
+    assert not (folder / "materials.npz").exists()
+
+    # And it loads back as hull, identical to before
+    scene2 = Scene.from_data(base_folder)
+    assert len(scene2.objects) == 1
+    np.testing.assert_array_almost_equal(
+        scene2.objects[0].faces[0].vertices,
+        obj.faces[0].vertices,
+    )
+
+
+def test_scene_export_import_lossless(tmp_path) -> None:
+    """Round-trip a scene via lossless mesh export and validate exact triangles."""
+    # A quad face (fans into 2 triangles, material 2) and a triangle face (material 5)
+    quad = Face([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], material_idx=2)
+    tri = Face([[0, 0, 1], [1, 0, 1], [0, 1, 1]], material_idx=5)
+    obj = PhysicalElement([quad, tri], name="MeshObj", object_id=7, label=CAT_BUILDINGS)
+
+    scene = Scene()
+    scene.add_object(obj)
+
+    base_folder = str(tmp_path / "scene_mesh")
+    metadata = scene.export_data(base_folder, lossless=True)
+
+    # Representation flag + mesh files present
+    assert metadata[SCENE_PARAM_REPRESENTATION] == SCENE_REPRESENTATION_MESH
+    assert metadata[SCENE_PARAM_N_TRIANGULAR_FACES] == 3
+    folder = Path(base_folder)
+    assert (folder / "vertices.npz").exists()
+    assert (folder / "faces.npz").exists()
+    assert (folder / "materials.npz").exists()
+    assert (folder / "objects.json").exists()
+
+    # Expected triangles (fan triangulation) and per-triangle materials, in order
+    expected_tris = [
+        np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0]]),
+        np.array([[0, 0, 0], [1, 1, 0], [0, 1, 0]]),
+        np.array([[0, 0, 1], [1, 0, 1], [0, 1, 1]]),
+    ]
+    expected_mats = [2, 2, 5]
+
+    scene2 = Scene.from_data(base_folder)
+    assert len(scene2.objects) == 1
+    obj2 = scene2.objects[0]
+    assert obj2.name == "MeshObj"
+    assert obj2.object_id == 7
+    assert obj2.label == CAT_BUILDINGS
+
+    # One Face per triangle, preserving exact geometry + material indexing
+    assert len(obj2.faces) == 3
+    for face, exp_tri, exp_mat in zip(obj2.faces, expected_tris, expected_mats, strict=True):
+        assert face.vertices.shape == (3, 3)
+        np.testing.assert_array_almost_equal(face.vertices, exp_tri)
+        assert face.material_idx == exp_mat
+
+
+def test_from_data_legacy_loads_as_hull(tmp_path) -> None:
+    """A scenario dir without a representation flag (legacy) loads as hull."""
+    obj = PhysicalElement(
+        [Face([[0, 0, 0], [1, 0, 0], [0, 1, 0]])],
+        name="Legacy",
+        label=CAT_OBJECTS,
+    )
+    scene = Scene()
+    scene.add_object(obj)
+
+    base_folder = str(tmp_path / "legacy_scene")
+    scene.export_data(base_folder)  # hull export leaves no mesh marker in the folder
+
+    # Simulate a legacy params.json whose scene block has no representation key
+    folder = Path(base_folder)
+    save_dict_as_json(str(folder / "params.json"), {"scene": {"num_scenes": 1, "n_objects": 1}})
+
+    assert Scene._is_mesh_representation(base_folder) is False  # noqa: SLF001
+    scene2 = Scene.from_data(base_folder)
+    assert len(scene2.objects) == 1
+    assert scene2.objects[0].name == "Legacy"
+    np.testing.assert_array_almost_equal(
+        scene2.objects[0].faces[0].vertices,
+        obj.faces[0].vertices,
+    )
+
+
 @patch("matplotlib.pyplot.subplots")
 def test_scene_plot(mock_subplots) -> None:
     """Test plotting calls."""
@@ -174,8 +274,7 @@ def test_scene_plot(mock_subplots) -> None:
 
 
 def test_get_object_faces() -> None:
-    """Compute face list for a simple cube in fast mode."""
-    # Test fast mode (convex hull)
+    """Compute face list for a simple cube via convex-hull generation."""
     # Cube vertices
     vertices = [
         [0, 0, 0],
@@ -187,7 +286,7 @@ def test_get_object_faces() -> None:
         [1, 1, 1],
         [0, 1, 1],
     ]
-    faces = get_object_faces(vertices, fast=True)
+    faces = get_object_faces(vertices)
     assert len(faces) >= 6  # Cube has 6 faces; hull count can vary with collinearity
     # For simple cube, it should return top, bottom + 4 sides = 6.
     assert len(faces) == 6
@@ -441,176 +540,11 @@ def test_get_faces_convex_hull_collinear_returns_none(capsys) -> None:
 
 
 # ---------------------------------------------------------------------------
-# _calculate_angle_deviation  (lines 961-968)
-# ---------------------------------------------------------------------------
-
-
-def test_calculate_angle_deviation_straight_line() -> None:
-    """Collinear points in the same direction give 0 degrees."""
-    p1 = np.array([0.0, 0.0])
-    p2 = np.array([1.0, 0.0])
-    p3 = np.array([2.0, 0.0])
-    angle = _calculate_angle_deviation(p1, p2, p3)
-    assert angle == pytest.approx(0.0, abs=1e-6)
-
-
-def test_calculate_angle_deviation_right_angle() -> None:
-    """A 90° turn gives approximately 90 degrees."""
-    p1 = np.array([0.0, 0.0])
-    p2 = np.array([1.0, 0.0])
-    p3 = np.array([1.0, 1.0])
-    angle = _calculate_angle_deviation(p1, p2, p3)
-    assert angle == pytest.approx(90.0, abs=1e-4)
-
-
-def test_calculate_angle_deviation_equal_points_returns_180() -> None:
-    """When p1==p2 or p2==p3 the function returns 180.0."""
-    p = np.array([1.0, 2.0])
-    # p1 == p2
-    assert _calculate_angle_deviation(p, p, np.array([3.0, 4.0])) == pytest.approx(180.0)
-    # p2 == p3
-    assert _calculate_angle_deviation(np.array([0.0, 0.0]), p, p) == pytest.approx(180.0)
-
-
-# ---------------------------------------------------------------------------
-# _ccw  (line 973)
-# ---------------------------------------------------------------------------
-
-
-def test_ccw_counter_clockwise() -> None:
-    """Points arranged counter-clockwise return a truthy value."""
-    a = np.array([0.0, 0.0])
-    b = np.array([1.0, 0.0])
-    c = np.array([0.0, 1.0])
-    assert _ccw(a, b, c)
-
-
-def test_ccw_clockwise() -> None:
-    """Points arranged clockwise return a falsy value."""
-    a = np.array([0.0, 0.0])
-    b = np.array([0.0, 1.0])
-    c = np.array([1.0, 0.0])
-    assert not _ccw(a, b, c)
-
-
-# ---------------------------------------------------------------------------
-# _segments_intersect  (line 978)
-# ---------------------------------------------------------------------------
-
-
-def test_segments_intersect_crossing() -> None:
-    """Two crossing diagonals of a square should intersect."""
-    p1 = np.array([0.0, 0.0])
-    p2 = np.array([1.0, 1.0])
-    q1 = np.array([1.0, 0.0])
-    q2 = np.array([0.0, 1.0])
-    assert _segments_intersect(p1, p2, q1, q2)
-
-
-def test_segments_intersect_parallel() -> None:
-    """Parallel horizontal segments do not intersect."""
-    p1 = np.array([0.0, 0.0])
-    p2 = np.array([1.0, 0.0])
-    q1 = np.array([0.0, 1.0])
-    q2 = np.array([1.0, 1.0])
-    assert not _segments_intersect(p1, p2, q1, q2)
-
-
-# ---------------------------------------------------------------------------
-# _tsp_held_karp_no_intersections  (lines 988-1044)
-# ---------------------------------------------------------------------------
-
-
-def test_tsp_held_karp_4_points() -> None:
-    """4 axis-aligned points: TSP should return a cost and a valid cyclic path."""
-    points = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
-    cost, path = _tsp_held_karp_no_intersections(points)
-    assert np.isfinite(cost)
-    assert len(path) >= 4  # at minimum visits all points
-    # path starts and ends at index 0
-    assert path[0] == 0
-    assert path[-1] == 0
-
-
-def test_tsp_held_karp_3_points() -> None:
-    """3 points: minimal non-trivial case."""
-    points = np.array([[0.0, 0.0], [2.0, 0.0], [1.0, 1.0]])
-    cost, path = _tsp_held_karp_no_intersections(points)
-    assert np.isfinite(cost)
-    # Path must visit all three points and close the loop
-    visited = set(path)
-    assert {0, 1, 2}.issubset(visited)
-
-
-# ---------------------------------------------------------------------------
-# _detect_endpoints  (lines 1063-1081)
-# ---------------------------------------------------------------------------
-
-
-def test_detect_endpoints_basic() -> None:
-    """detect_endpoints returns 4 indices identifying the two farthest pairs."""
-    # Simple grid: farthest apart should be the outer corners
-    points = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [0.0, 5.0], [1.0, 5.0], [2.0, 5.0]])
-    endpoints = _detect_endpoints(points)
-    assert len(endpoints) == 4
-    # All returned indices must be valid
-    for idx in endpoints:
-        assert 0 <= idx < len(points)
-
-
-def test_detect_endpoints_deduplicates_nearby() -> None:
-    """Points within min_distance are treated as a single point."""
-    # Two groups of near-duplicates far apart
-    points = np.array(
-        [
-            [0.0, 0.0],
-            [0.01, 0.0],  # near-duplicate at origin
-            [100.0, 0.0],
-            [100.01, 0.0],
-        ]  # near-duplicate far away
-    )
-    endpoints = _detect_endpoints(points, min_distance=0.05)
-    # Should only have one representative per cluster
-    assert len(endpoints) == 4  # function always returns 4 index slots
-
-
-# ---------------------------------------------------------------------------
-# _signed_distance_to_curve  (lines 1102-1116)
-# ---------------------------------------------------------------------------
-
-
-def test_signed_distance_to_curve_on_curve() -> None:
-    """A point on the fitted curve should have near-zero signed distance."""
-    # Flat line y=0 fitted by quadratic → curve is y=0 for all x
-    x_pts = np.linspace(0, 10, 20)
-    y_pts = np.zeros_like(x_pts)
-    z_coeffs = np.polyfit(x_pts, y_pts, 3)
-    curve_fit = np.poly1d(z_coeffs)
-
-    point = np.array([5.0, 0.0])
-    signed_dist, closest = _signed_distance_to_curve(point, curve_fit, (0.0, 10.0))
-    assert abs(signed_dist) < 0.1
-    assert closest.shape == (2,)
-
-
-def test_signed_distance_to_curve_off_curve() -> None:
-    """A point clearly above the curve has a non-zero signed distance."""
-    x_pts = np.linspace(0, 10, 30)
-    y_pts = np.zeros(30)
-    z_coeffs = np.polyfit(x_pts, y_pts, 3)
-    curve_fit = np.poly1d(z_coeffs)
-
-    point = np.array([5.0, 10.0])  # 10 units above the curve
-    signed_dist, _ = _signed_distance_to_curve(point, curve_fit, (0.0, 10.0))
-    assert abs(signed_dist) > 5.0
-
-
-# ---------------------------------------------------------------------------
 # get_object_faces - too few vertices returns None (line 1282)
 # ---------------------------------------------------------------------------
 
 
 def test_get_object_faces_too_few_vertices() -> None:
     """Fewer than 3 vertices returns None."""
-    result = get_object_faces([[0, 0, 0], [1, 0, 0]], fast=True)
+    result = get_object_faces([[0, 0, 0], [1, 0, 0]])
     assert result is None

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -6,6 +6,13 @@ import numpy as np
 import pytest
 
 from deepmimo import consts as c
+from deepmimo.core.scene import (
+    CAT_BUILDINGS,
+    CAT_TERRAIN,
+    Face,
+    PhysicalElement,
+    Scene,
+)
 from deepmimo.datasets.compat_v3 import _apply_v3_compat, _merge_rx_grids_v3, _rx_rank_map
 from deepmimo.datasets.dataset import (
     SHARED_PARAMS,
@@ -15,7 +22,9 @@ from deepmimo.datasets.dataset import (
     MacroDataset,
     MergedGridDataset,
     _missing_user_array,
+    _nearest_triangle_object_ids,
     _pad_concat_users,
+    _point_triangle_distances,
     merge_datasets,
 )
 from deepmimo.datasets.load import _validate_txrx_sets
@@ -1627,6 +1636,120 @@ def test_compute_path_hash_inactive_user_gets_minus_one() -> None:
     ds["path_ids"] = path_ids
     user_hashes = ds._compute_path_hash()  # noqa: SLF001
     assert user_hashes[1] == -1
+
+
+# ===========================================================================
+# _compute_inter_objects: mesh (nearest triangular face) vs hull (bbox center)
+# ===========================================================================
+
+
+def _wall_faces(x0, x1, y0, y1, z0, z1) -> list[Face]:  # noqa: PLR0913
+    """Two opposing axis-aligned walls at x=x0 and x=x1 (defines a box bbox)."""
+    lo = Face([[x0, y0, z0], [x0, y1, z0], [x0, y1, z1], [x0, y0, z1]])
+    hi = Face([[x1, y0, z0], [x1, y1, z0], [x1, y1, z1], [x1, y0, z1]])
+    return [lo, hi]
+
+
+def _make_inter_object_scene() -> Scene:
+    """Scene where the nearest *face* and nearest bbox *center* disagree.
+
+    - terrain: flat ground at z=0 (z-snap target, object_id 0).
+    - obj A (id 1): elongated box x in [1, 21] -> a face sits ~1 m from the
+      probe point at (0, 0, 5) but its bbox center is far away at (11, 0, 5).
+    - obj B (id 2): compact box x in [-6, -4] -> bbox center (-5, 0, 5) is closer
+      than A's center, yet its nearest face is ~4 m away.
+
+    So for the probe point (0, 0, 5): hull picks B (center dist 5 < 11) while the
+    mesh path picks A (face dist 1 < 4).
+    """
+    terrain = PhysicalElement(
+        [Face([[-50, -50, 0], [50, -50, 0], [50, 50, 0], [-50, 50, 0]])],
+        object_id=0,
+        label=CAT_TERRAIN,
+        name="terrain",
+    )
+    obj_a = PhysicalElement(
+        _wall_faces(1, 21, -1, 1, 0, 10), object_id=1, label=CAT_BUILDINGS, name="A"
+    )
+    obj_b = PhysicalElement(
+        _wall_faces(-6, -4, -1, 1, 4, 6), object_id=2, label=CAT_BUILDINGS, name="B"
+    )
+    scene = Scene()
+    scene.add_object(terrain)
+    scene.add_object(obj_a)
+    scene.add_object(obj_b)
+    return scene
+
+
+def _make_inter_object_dataset(point: list[float]) -> Dataset:
+    """One UE / one path / one (reflection) interaction at ``point``."""
+    data = {
+        "rx_pos": np.array([[0.0, 0.0, 1.5]], dtype=float),
+        "tx_pos": np.array([0.0, 0.0, 10.0], dtype=float),
+        "aoa_az": np.array([[0.0]], dtype=float),
+        "inter": np.array([[1.0]], dtype=float),
+        "inter_pos": np.array([[[point]]], dtype=float),
+    }
+    ds = Dataset(data)
+    ds.scene = _make_inter_object_scene()
+    return ds
+
+
+def test_point_triangle_distances_matches_known_geometry() -> None:
+    """Exact point-to-triangle distance for interior, edge, vertex, and tilted cases."""
+    v0 = np.array([[0.0, 0.0, 0.0]])
+    v1 = np.array([[1.0, 0.0, 0.0]])
+    v2 = np.array([[0.0, 1.0, 0.0]])
+    # Interior projection -> pure plane (height) distance
+    d = _point_triangle_distances(np.array([[0.2, 0.2, 3.0]]), v0, v1, v2)
+    assert d[0, 0] == pytest.approx(3.0)
+    # In-plane but past an edge -> distance to that edge segment
+    d = _point_triangle_distances(np.array([[0.5, -2.0, 0.0]]), v0, v1, v2)
+    assert d[0, 0] == pytest.approx(2.0)
+    # Past a vertex -> distance to the vertex
+    d = _point_triangle_distances(np.array([[-1.0, -1.0, 0.0]]), v0, v1, v2)
+    assert d[0, 0] == pytest.approx(np.sqrt(2.0))
+    # Off-plane and outside -> combines edge + height
+    d = _point_triangle_distances(np.array([[2.0, 2.0, 1.0]]), v0, v1, v2)
+    assert d[0, 0] == pytest.approx(np.sqrt(5.5))
+
+
+def test_nearest_triangle_object_ids_chunking_is_stable() -> None:
+    """Chunked evaluation yields the same assignment as a single-shot pass."""
+    v0 = np.array([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]])
+    v1 = np.array([[1.0, 0.0, 0.0], [11.0, 0.0, 0.0]])
+    v2 = np.array([[0.0, 1.0, 0.0], [10.0, 1.0, 0.0]])
+    tri_obj_ids = np.array([100, 200])
+    points = np.array([[0.1, 0.1, 0.5], [10.2, 0.2, 0.5], [0.0, 0.0, 9.0]])
+    full = _nearest_triangle_object_ids(points, v0, v1, v2, tri_obj_ids)
+    chunked = _nearest_triangle_object_ids(points, v0, v1, v2, tri_obj_ids, pair_budget=2)
+    np.testing.assert_array_equal(full, chunked)
+    np.testing.assert_array_equal(full, [100, 200, 100])
+
+
+def test_compute_inter_objects_hull_uses_bbox_center() -> None:
+    """Hull scene: interaction point assigned to nearest bbox-center object (B)."""
+    ds = _make_inter_object_dataset([0.0, 0.0, 5.0])
+    assert ds.scene.representation == c.SCENE_REPRESENTATION_HULL
+    ids = ds._compute_inter_objects()  # noqa: SLF001
+    assert ids[0, 0, 0] == 2  # object B (nearest center), not A
+
+
+def test_compute_inter_objects_mesh_uses_nearest_face() -> None:
+    """Mesh scene: same point assigned to object owning the nearest triangle (A)."""
+    ds = _make_inter_object_dataset([0.0, 0.0, 5.0])
+    ds.scene.representation = c.SCENE_REPRESENTATION_MESH
+    ids = ds._compute_inter_objects()  # noqa: SLF001
+    assert ids[0, 0, 0] == 1  # object A (nearest face), differs from hull result
+
+
+def test_compute_inter_objects_terrain_snap_unchanged_in_both_modes() -> None:
+    """A point at the terrain top z-snaps to the terrain object in both modes."""
+    for representation in (c.SCENE_REPRESENTATION_HULL, c.SCENE_REPRESENTATION_MESH):
+        ds = _make_inter_object_dataset([3.0, 4.0, 0.0])
+        ds.scene.representation = representation
+        ids = ds._compute_inter_objects()  # noqa: SLF001
+        assert ids[0, 0, 0] == 0  # terrain object_id
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Implements the optional, backward-compatible **lossless (triangular-mesh) scene representation** from #99, and removes the flaky OSM-dependent **roads** feature.

### Lossless scene format
- Scenes can be exported/loaded as true triangular **meshes** (`faces.npz` + `materials.npz`) with a `representation` flag (`"hull"` vs `"mesh"`), via `Scene.export_data(lossless=True)`, `from_data`, and the `*_rt_converter` entry points.
- Existing **hull** scenarios load byte-identically and behave exactly as before — the mesh path is purely additive and opt-in (default `representation = "hull"`).

### More accurate interaction-object assignment for mesh scenes
- For mesh scenes, `Dataset._compute_inter_objects` assigns each non-terrain interaction point to the object owning the nearest **triangular face** using exact point-to-triangle distance (vectorized + chunked to bound memory) — far more accurate than the hull bounding-box-center heuristic.
- Hull/legacy scenes keep the original (now vectorized, from #111) nearest-center assignment byte-for-byte via a `representation` dispatch; terrain z-snap behavior is unchanged in both modes.

### Roads removal
- Removes all road / 2D-mesh / TSP machinery; convex hull is now the only hull face-generation path (`scene.py`, the InSite/Sionna converters, and the blender/InSite pipelines). This OSM-dependent feature was a recurring source of errors.

## Backward compatibility
- Default behavior is unchanged: legacy/hull scenarios are byte-identical.
- Mesh support is strictly opt-in via `export_data(lossless=True)` / the `representation` flag.

## Test plan
- [x] `pytest` full suite green (679 passed, 9 skipped)
- [x] `ruff check` + `ruff format --check` clean
- [x] Up to date with `main` (channel/interaction/p2m speedups #111, ruff pre-commit #112); the single `dataset.py` conflict resolved by keeping both helper sets, so mesh scenes use point-to-triangle while hull scenes use the vectorized nearest-center path
- [x] Scene round-trip tests (hull + mesh), `representation` flag, terrain z-snap, and nearest-face interaction-object assignment