### PR TITLE
Bump version to v4.0.2

### DIFF
--- a/deepmimo/__init__.py
+++ b/deepmimo/__init__.py
@@ -1,6 +1,6 @@
 """DeepMIMO Python Package."""
 
-__version__ = "4.0.1"
+__version__ = "4.0.2"
 
 # Core functionality
 # Import immediate modules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "DeepMIMO"
-version = "4.0.1"
+version = "4.0.2"
 authors = [
     { name = "João Morais" },
     { name = "Umut Demirhan" },

--- a/uv.lock
+++ b/uv.lock
@@ -755,7 +755,7 @@ wheels = [
 
 [[package]]
 name = "deepmimo"
-version = "4.0.1"
+version = "4.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.10.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
## Summary

Bumps the package version **4.0.1 → 4.0.2** (in `pyproject.toml`, `deepmimo/__init__.py`, and the project's own `uv.lock` entry) in preparation for the PyPI release.

This is the release-tagging PR for everything merged since `v4.0.1` (PRs #100–#114). Nothing else changes; all feature/perf work already landed on `main`.

## Release summary (v4.0.2)

### New features
| Feature | What it does | PR |
|---|---|---|
| Lossless (mesh) scene format | Optional triangular-mesh scene representation (`Scene.export_data(lossless=True)`, `representation="mesh"`) alongside the default convex hull — strictly opt-in and backward compatible | #113 |
| Nearest-face interaction objects | Mesh scenes assign each interaction point to the object owning the nearest triangle (exact point-to-triangle distance) instead of the hull bounding-box-center heuristic | #113 |
| Programmable channel precision | Channel / array-response complex dtype is now a parameter; generation runs in `complex64` (≈½ the memory) while staying within `rtol=1e-4` of the `complex128` result | #111 |
| ruff pre-commit hook | `.pre-commit-config.yaml` mirrors the CI ruff gates so lint + format run locally before every commit | #112 |

### Performance benefits
| Hot path | Speedup | PR |
|---|---|---|
| Sionna RT → DeepMIMO path conversion | **~66×** (15.6 s → 0.24 s on a 32,400-rx export) | #114 |
| MIMO channel generation — time domain | up to **~61×** | #111 |
| MIMO channel generation — frequency domain | up to **~11×** | #111 |
| Interaction angles / inter-objects / Doppler | **~13–61×** | #111 |
| OFDM frequency delay phase | **~6×** (≈2× end-to-end frequency `compute_channels`) | #111 |
| Wireless InSite p2m path parser | **~2.2×** | #111 |

### Benefits (accuracy, memory, maintenance)
| Benefit | Detail | PR |
|---|---|---|
| Lower channel-gen memory | `complex64` chunked contraction cuts peak memory ~1.5× (win scales as M_rx·M_tx vs M_rx+M_tx) | #111 |
| More accurate OFDM delay phase | Subcarrier-recurrence matches `complex128` to ~5e-7 — more accurate than the prior float32 `exp` | #111 |
| Numerically safe optimizations | Channel within `rtol=1e-4`; interactions/Doppler `rtol=1e-6`; p2m + Sionna conversions byte-for-byte identical | #111, #114 |
| Backward compatible | Hull scenarios load byte-identically; the mesh format is purely additive/opt-in | #113 |
| Fewer flaky failures | Removed the OSM-dependent roads / 2D-mesh / TSP machinery (a recurring error source) | #113 |
| Tighter CI parity | pre-commit ruff hook stops lint/format issues before they reach CI | #112 |
| Dependency maintenance | Routine security/maintenance dependency bumps | #100–#110 |

## Benchmarks (from #111)

MIMO channel generation — per-UE loop vs vectorized (log-log time; blue = speedup):

<img width="2040" height="1140" alt="MIMO channel generation benchmark" src="https://github.com/user-attachments/assets/ae4530d3-cb3d-49c0-8fab-6b18122b60fc" />

Interaction / Doppler computations — loop vs vectorized:

<img width="2040" height="1140" alt="Interaction and Doppler benchmark" src="https://github.com/user-attachments/assets/f551200d-389b-48fb-919a-652c4fcfb18b" />

## Test plan
- [x] Version is `4.0.2` in `pyproject.toml`, `deepmimo/__init__.py`, and the `deepmimo` entry in `uv.lock`
- [x] No other code changes (all features/perf already on `main`)
- [ ] After merge: tag `v4.0.2` and publish to PyPI
