### PR TITLE
Fix indoor scene geometry in the Wireless InSite converter (#126)

### DIFF
--- a/deepmimo/converters/wireless_insite/insite_converter.py
+++ b/deepmimo/converters/wireless_insite/insite_converter.py
@@ -120,7 +120,7 @@ def insite_rt_converter(  # noqa: PLR0913
     materials_dict = read_materials(rt_folder)
 
     # Read scene objects
-    scene = read_scene(rt_folder)
+    scene = read_scene(rt_folder, lossless=lossless)
     scene_dict = scene.export_data(temp_folder, lossless=lossless)
     scene_dict[c.SCENE_PARAM_NUMBER_SCENES] = num_scenes
 

--- a/deepmimo/converters/wireless_insite/insite_materials.py
+++ b/deepmimo/converters/wireless_insite/insite_materials.py
@@ -16,6 +16,7 @@ and DeepMIMO's standardized material representation.
 import os
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from deepmimo.core.materials import Material, MaterialList  # Base material classes
 
@@ -161,6 +162,125 @@ class InsiteFoliage:
         )
 
 
+# Extensions of files that declare materials. Wireless InSite writes standalone
+# geometry as ".object"; ".obj" is kept for compatibility with renamed exports.
+MATERIAL_FILE_EXTS = (".city", ".ter", ".veg", ".flp", ".obj", ".object")
+
+
+def _outer_layer(mat: Any) -> Any:
+    """Return the dielectric layer used to characterise a material.
+
+    Layered materials (e.g. "ITU Layered drywall") declare several
+    ``begin_<DielectricLayer>`` blocks. They are parsed into a list; the last
+    entry is used, matching the value this parser has always reported for
+    single-layer materials.
+
+    Args:
+        mat: Parsed material node.
+
+    Returns:
+        The dielectric layer node to read properties from.
+
+    """
+    layers = mat.all_values.get("DielectricLayer")
+    return layers[-1] if layers else mat.values["DielectricLayer"]
+
+
+# Conductivity used for perfect electric conductors. Wireless InSite marks these
+# with a bare "PEC" label and declares no dielectric layer. A large finite value is
+# used instead of infinity so the exported material stays valid JSON, and is
+# numerically equivalent for reflection (|gamma| ~ 1 either way).
+PEC_CONDUCTIVITY = 1e7
+PEC_PERMITTIVITY = 1.0
+
+
+def _build_material(mat: Any) -> Material:
+    """Build a Material from a parsed Wireless Insite material node.
+
+    Args:
+        mat: Parsed material node.
+
+    Returns:
+        The corresponding Material.
+
+    """
+    if "PEC" in mat.labels:
+        return InsiteMaterial(
+            name=mat.name,
+            diffuse_scattering_model=mat.values.get("diffuse_scattering_model", ""),
+            fields_diffusively_scattered=float(
+                mat.values.get("fields_diffusively_scattered", 0.0),
+            ),
+            cross_polarized_power=float(mat.values.get("cross_polarized_power", 0.0)),
+            directive_alpha=float(mat.values.get("directive_alpha", 4.0)),
+            directive_beta=float(mat.values.get("directive_beta", 4.0)),
+            directive_lambda=float(mat.values.get("directive_lambda", 0.5)),
+            conductivity=PEC_CONDUCTIVITY,
+            permittivity=PEC_PERMITTIVITY,
+            roughness=float(mat.values.get("roughness", 0.0)),
+            thickness=float(mat.values.get("thickness", 0.0)),
+        ).to_material()
+
+    if "diffuse_scattering_model" not in mat.values and mat.values.get("thickness", False):
+        # Foliage!
+        insite_mat = InsiteFoliage(
+            name=mat.name,
+            thickness=float(mat.values["thickness"]),
+            density=float(mat.values["density"]),
+            vertical_attenuation=float(mat.values["VerticalAttenuation"]),
+            horizontal_attenuation=float(mat.values["HorizontalAttenuation"]),
+            permittivity_vr=float(mat.values["permittivity_vr"]),
+            permittivity_hr=float(mat.values["permittivity_hr"]),
+        )
+    else:
+        insite_mat = InsiteMaterial(
+            name=mat.name,
+            diffuse_scattering_model=mat.values.get("diffuse_scattering_model", ""),
+            fields_diffusively_scattered=float(
+                mat.values.get("fields_diffusively_scattered", 0.0),
+            ),
+            cross_polarized_power=float(mat.values.get("cross_polarized_power", 0.0)),
+            directive_alpha=float(mat.values.get("directive_alpha", 4.0)),
+            directive_beta=float(mat.values.get("directive_beta", 4.0)),
+            directive_lambda=float(mat.values.get("directive_lambda", 0.5)),
+            conductivity=float(_outer_layer(mat).values["conductivity"]),
+            permittivity=float(_outer_layer(mat).values["permittivity"]),
+            roughness=float(_outer_layer(mat).values["roughness"]),
+            thickness=float(_outer_layer(mat).values["thickness"]),
+        )
+    return insite_mat.to_material()
+
+
+def parse_materials_with_indices(file: Path) -> list[tuple[int, Material]]:
+    """Parse materials from a file, keeping the index each one declares.
+
+    Wireless InSite faces reference materials by the index written inside the
+    material block (``Material 3``). Those indices are neither contiguous nor
+    equal to the order of declaration, so they must be read explicitly rather
+    than inferred from position.
+
+    Args:
+        file: Path to file to read.
+
+    Returns:
+        List of (declared index, material) pairs, in order of declaration.
+
+    """
+    document = parse_file(file)
+    indexed = []
+
+    for prim in document:
+        # all_values keeps every <Material> block; values would keep only the last.
+        mat_entries = document[prim].all_values.get("Material", [])
+        for mat in mat_entries:
+            # Fall back to declaration order for files that omit the index.
+            declared = mat.values.get("Material")
+            declared_idx = int(declared) if isinstance(declared, int | str) else len(indexed)
+            indexed.append((declared_idx, _build_material(mat)))
+
+    return indexed
+
+
 def parse_materials_from_file(file: Path) -> list[Material]:
     """Parse materials from a single Wireless Insite file.
 
@@ -171,47 +291,7 @@ def parse_materials_from_file(file: Path) -> list[Material]:
         List of Material objects
 
     """
-    document = parse_file(file)
-    materials = []
-
-    for prim in document:
-        mat_entries = document[prim].values["Material"]
-        mat_entries = [mat_entries] if not isinstance(mat_entries, list) else mat_entries
-
-        for mat in mat_entries:
-            if "diffuse_scattering_model" not in mat.values and mat.values.get("thickness", False):
-                # Foliage!
-                insite_mat = InsiteFoliage(
-                    name=mat.name,
-                    thickness=float(mat.values["thickness"]),
-                    density=float(mat.values["density"]),
-                    vertical_attenuation=float(mat.values["VerticalAttenuation"]),
-                    horizontal_attenuation=float(mat.values["HorizontalAttenuation"]),
-                    permittivity_vr=float(mat.values["permittivity_vr"]),
-                    permittivity_hr=float(mat.values["permittivity_hr"]),
-                )
-            else:
-                # Create InsiteMaterial object
-                insite_mat = InsiteMaterial(
-                    name=mat.name,
-                    diffuse_scattering_model=mat.values.get("diffuse_scattering_model", ""),
-                    fields_diffusively_scattered=float(
-                        mat.values.get("fields_diffusively_scattered", 0.0),
-                    ),
-                    cross_polarized_power=float(mat.values.get("cross_polarized_power", 0.0)),
-                    directive_alpha=float(mat.values.get("directive_alpha", 4.0)),
-                    directive_beta=float(mat.values.get("directive_beta", 4.0)),
-                    directive_lambda=float(mat.values.get("directive_lambda", 0.5)),
-                    conductivity=float(mat.values["DielectricLayer"].values["conductivity"]),
-                    permittivity=float(mat.values["DielectricLayer"].values["permittivity"]),
-                    roughness=float(mat.values["DielectricLayer"].values["roughness"]),
-                    thickness=float(mat.values["DielectricLayer"].values["thickness"]),
-                )
-
-            # Convert to base Material
-            materials.append(insite_mat.to_material())
-
-    return materials
+    return [material for _, material in parse_materials_with_indices(file)]
 
 
 def read_materials(sim_folder: str, *, verbose: bool = False) -> dict:
@@ -235,7 +315,7 @@ def read_materials(sim_folder: str, *, verbose: bool = False) -> dict:
 
     # Find all material files
     material_files = []
-    for ext in [".city", ".ter", ".veg", ".flp", ".obj"]:
+    for ext in MATERIAL_FILE_EXTS:
         material_files.extend(sim_folder.glob(f"*{ext}"))
 
     if not material_files:

--- a/deepmimo/converters/wireless_insite/insite_scene.py
+++ b/deepmimo/converters/wireless_insite/insite_scene.py
@@ -5,11 +5,13 @@ from Wireless InSite into DeepMIMO's physical object representation.
 """
 
 import re
+from dataclasses import astuple
 from pathlib import Path
 
 import numpy as np
 from tqdm import tqdm
 
+from deepmimo.core.materials import MaterialList
 from deepmimo.core.scene import (
     CAT_BUILDINGS,
     CAT_FLOORPLANS,
@@ -22,6 +24,8 @@ from deepmimo.core.scene import (
     get_object_faces,
 )
 
+from .insite_materials import parse_materials_with_indices
+
 # Map file extensions to their corresponding labels
 OBJECT_LABELS: dict[str, str] = {
     ".city": CAT_BUILDINGS,
@@ -29,10 +33,49 @@ OBJECT_LABELS: dict[str, str] = {
     ".veg": CAT_VEGETATION,
     ".flp": CAT_FLOORPLANS,
     ".obj": CAT_OBJECTS,
+    ".object": CAT_OBJECTS,
 }
 
+# Blocks and fields used by the geometry-preserving parser.
+RE_FACE = re.compile(r"begin_<face>(.*?)end_<face>", re.DOTALL)
+RE_FACE_MATERIAL = re.compile(r"^\s*Material\s+(\d+)\s*$", re.MULTILINE)
+RE_FACE_VERTEX = re.compile(
+    r"^\s*(-?\d+\.\d+)\s+(-?\d+\.\d+)\s+(-?\d+\.\d+)\s*$",
+    re.MULTILINE,
+)
 
-def read_scene(folder_path: str | Path) -> Scene:
+
+def build_material_maps(files: list[str]) -> dict[str, dict[int, int]]:
+    """Map each file's declared material indices onto the scenario material list.
+
+    Wireless InSite numbers materials per file, and those numbers are neither
+    contiguous nor ordered by declaration, so the mapping has to be built from
+    the indices the files actually declare. The scenario-wide list is assembled
+    in the same order as :func:`~deepmimo.converters.wireless_insite.
+    insite_materials.read_materials` so the indices agree with ``params.json``.
+
+    Args:
+        files: Paths of the geometry files, in the order materials are read.
+
+    Returns:
+        Mapping of file path to {index declared in file: scenario-wide index}.
+
+    """
+    material_list = MaterialList()
+    material_maps: dict[str, dict[int, int]] = {}
+    for file in files:
+        indexed = parse_materials_with_indices(Path(file))
+        material_list.add_materials([material for _, material in indexed])
+        global_keys = [astuple(mat)[1:] for mat in material_list._materials]  # noqa: SLF001
+        material_maps[file] = {
+            declared_idx: global_keys.index(astuple(material)[1:])
+            for declared_idx, material in indexed
+            if astuple(material)[1:] in global_keys
+        }
+    return material_maps
+
+
+def read_scene(folder_path: str | Path, *, lossless: bool = False) -> Scene:
     """Create a Scene from a folder containing Wireless InSite files.
 
     This function searches the given folder for .city, .ter, and .veg files
@@ -40,6 +83,9 @@ def read_scene(folder_path: str | Path) -> Scene:
 
     Args:
         folder_path: Path to folder containing Wireless InSite files
+        lossless: If True, keep the exact geometry declared in the files instead
+            of simplifying each object to its convex hull. Required for indoor
+            scenes, where the hull collapses a room and its contents into a box.
 
     Returns:
         Scene containing all objects from the files
@@ -68,6 +114,9 @@ def read_scene(folder_path: str | Path) -> Scene:
         msg = f"No valid files (.city, .ter, .veg) found in {folder}"
         raise ValueError(msg)
 
+    ordered_files = [file for type_files in found_files.values() for file in type_files]
+    material_maps = build_material_maps(ordered_files) if lossless else {}
+
     # Parse each type of file and add to scene
     for type_files in found_files.values():
         if not type_files:
@@ -75,7 +124,12 @@ def read_scene(folder_path: str | Path) -> Scene:
 
         # Parse all files of this type
         for file in type_files:
-            parser = PhysicalObjectParser(file, starting_id=next_object_id)
+            parser = PhysicalObjectParser(
+                file,
+                starting_id=next_object_id,
+                lossless=lossless,
+                material_map=material_maps.get(file),
+            )
             objects = parser.parse()
             next_object_id += len(objects)  # Update next available ID
             scene.add_objects(objects)
@@ -86,14 +140,27 @@ def read_scene(folder_path: str | Path) -> Scene:
 class PhysicalObjectParser:
     """Parser for Wireless InSite physical object files (.city, .ter, .veg)."""
 
-    def __init__(self, file_path: str, starting_id: int = 0) -> None:
+    def __init__(
+        self,
+        file_path: str,
+        starting_id: int = 0,
+        *,
+        lossless: bool = False,
+        material_map: dict[int, int] | None = None,
+    ) -> None:
         """Initialize parser with file path.
 
         Args:
             file_path: Path to the physical object file (.city, .ter, .veg)
             starting_id: Starting ID for objects in this file (default: 0)
+            lossless: If True, keep each face exactly as declared in the file
+                instead of replacing the object with its convex hull.
+            material_map: Maps the material indices declared in this file to
+                indices in the scenario-wide material list.
 
         """
+        self.lossless = lossless
+        self.material_map = material_map or {}
         self.file_path = Path(file_path)
         if self.file_path.suffix not in OBJECT_LABELS:
             msg = f"Unsupported file type: {self.file_path.suffix}"
@@ -116,6 +183,9 @@ class PhysicalObjectParser:
 
         file_base = Path(self.file_path).name
 
+        if self.lossless:
+            return self._parse_lossless(content)
+
         # Extract objects using extract_objects
         object_vertices = extract_objects(content)
 
@@ -129,12 +199,12 @@ class PhysicalObjectParser:
         ):
             vertices_array = np.array(vertices)
 
-            self.name = f"{self.name}_{i}"
+            name = f"{self.name}_{i}"
 
             # Generate faces using the convex-hull approach
             object_faces = get_object_faces(vertices_array)
             if object_faces is None:
-                print(f"Failed to generate faces for object {self.name}")
+                print(f"Failed to generate faces for object {name}")
                 continue
 
             # Convert faces to Face objects
@@ -143,13 +213,108 @@ class PhysicalObjectParser:
             # Create PhysicalElement object with appropriate label and global ID
             obj = PhysicalElement(
                 faces=faces,
-                name=self.name,
+                name=name,
                 object_id=self.starting_id + i,
                 label=self.label,
             )
             objects.append(obj)
 
         return objects
+
+    def _parse_lossless(self, content: str) -> list[PhysicalElement]:
+        """Parse the file keeping every face exactly as declared.
+
+        Args:
+            content: Raw file content.
+
+        Returns:
+            List of PhysicalElement objects with their original geometry.
+
+        """
+        objects = []
+        for i, face_tuples in enumerate(extract_object_faces(content)):
+            faces = [
+                Face(
+                    vertices=np.array(vertices),
+                    material_idx=self.material_map.get(material_idx, 0),
+                )
+                for material_idx, vertices in face_tuples
+            ]
+            objects.append(
+                PhysicalElement(
+                    faces=faces,
+                    name=f"{self.name}_{i}",
+                    object_id=self.starting_id + i,
+                    label=self.label,
+                ),
+            )
+        return objects
+
+
+def parse_face_block(block: str) -> tuple[int, list[tuple[float, float, float]]] | None:
+    """Parse a single ``begin_<face>`` block.
+
+    Args:
+        block: Text between the face block delimiters.
+
+    Returns:
+        Tuple of (material index declared on the face, vertex list), or None if
+        the block holds fewer than three vertices.
+
+    """
+    min_vertices_for_face = 3
+    vertices = [(float(x), float(y), float(z)) for x, y, z in RE_FACE_VERTEX.findall(block)]
+    if len(vertices) < min_vertices_for_face:
+        return None
+    material_match = RE_FACE_MATERIAL.search(block)
+    material_idx = int(material_match.group(1)) if material_match else 0
+    return material_idx, vertices
+
+
+def extract_object_faces(content: str) -> list[list[tuple[int, list]]]:
+    """Group a file's faces into objects, preserving their exact geometry.
+
+    Faces are grouped by shared vertices, the same connectivity rule
+    :func:`extract_objects` uses, so an object contains the same faces in either
+    representation. Unlike :func:`extract_objects` - which reduces each object to
+    a bag of vertices for the convex-hull path - this keeps the declared faces and
+    their material indices, which is what indoor scenes need: a hull turns a room
+    into a solid block and discards its vertical walls entirely.
+
+    Args:
+        content: Raw file content from a Wireless InSite object file.
+
+    Returns:
+        List of objects, each a list of (material index, vertices) face tuples.
+
+    """
+    faces = []
+    vertex_to_faces: dict[tuple[float, float, float], set[int]] = {}
+    for block in RE_FACE.findall(content):
+        parsed = parse_face_block(block)
+        if parsed is None:
+            continue
+        idx = len(faces)
+        faces.append(parsed)
+        for vertex in parsed[1]:
+            vertex_to_faces.setdefault(vertex, set()).add(idx)
+
+    objects = []
+    processed: set[int] = set()
+    for start in range(len(faces)):
+        if start in processed:
+            continue
+        group, stack = [], [start]
+        while stack:
+            current = stack.pop()
+            if current in processed:
+                continue
+            processed.add(current)
+            group.append(current)
+            for vertex in faces[current][1]:
+                stack.extend(vertex_to_faces[vertex] - processed)
+        objects.append([faces[i] for i in sorted(group)])
+    return objects
 
 
 def extract_objects(content: str) -> list[list[tuple[float, float, float]]]:

--- a/deepmimo/converters/wireless_insite/setup_parser.py
+++ b/deepmimo/converters/wireless_insite/setup_parser.py
@@ -130,6 +130,10 @@ class Node:
     values: dict = field(default_factory=dict)
     labels: list = field(default_factory=list)
     data: list = field(default_factory=list)
+    # Every occurrence of each label, in file order. ``values`` keeps only the
+    # last one, which is all most callers want; readers that need repeated
+    # sibling blocks (several <Material> blocks in one file) use this instead.
+    all_values: dict = field(default_factory=dict)
 
     def __getitem__(self, key: str) -> Any:
         """Access node values using dictionary notation.
@@ -236,14 +240,34 @@ def parse_node(tokens: Any) -> tuple[str, Node]:
             case [str(label)]:
                 node.labels.append(label)
             case [str(label), value]:
-                node[label] = value
+                _assign_label(node, label, value)
             case [str(label), *rest]:
-                node[label] = rest
+                _assign_label(node, label, rest)
             case _:
                 node.data.append(value)
     eat(tokens, f"end_<{node_name}>")
     eat(tokens, NL_TOKEN)
     return (node_name, node)
+
+
+def _assign_label(node: Node, label: str, value: Any) -> None:
+    """Assign a label on a node, recording every occurrence of it.
+
+    Wireless InSite files repeat sibling blocks under the same label (several
+    ``begin_<Material>`` blocks in one file, several ``begin_<DielectricLayer>``
+    blocks in one material). ``values`` keeps the last occurrence, which is the
+    long-standing behaviour every caller is written against; ``all_values``
+    additionally keeps them all so readers that need the full set can get it
+    without changing what existing callers see.
+
+    Args:
+        node: Node being populated.
+        label: Label to assign.
+        value: Value to assign.
+
+    """
+    node[label] = value
+    node.all_values.setdefault(label, []).append(value)
 
 
 def parse_values(tokens: Any) -> Any:

--- a/tests/converters/wireless_insite/test_insite_materials.py
+++ b/tests/converters/wireless_insite/test_insite_materials.py
@@ -43,18 +43,23 @@ def test_insite_foliage_conversion() -> None:
 def test_read_materials(mock_parse) -> None:
     """Read and normalize materials from mocked Wireless Insite files."""
     # Mock document structure
-    mat_node = MagicMock()
-    mat_node.name = "Mat1"
-    mat_node.values = {"diffuse_scattering_model": "lambertian", "DielectricLayer": MagicMock()}
-    mat_node.values["DielectricLayer"].values = {
+    layer = MagicMock()
+    layer.values = {
         "conductivity": 1.0,
         "permittivity": 2.0,
         "roughness": 0.0,
         "thickness": 0.1,
     }
+    mat_node = MagicMock()
+    mat_node.name = "Mat1"
+    mat_node.labels = []
+    mat_node.values = {"diffuse_scattering_model": "lambertian", "DielectricLayer": layer}
+    mat_node.all_values = {"DielectricLayer": [layer]}
 
     root_node = MagicMock()
-    root_node.values = {"Material": [mat_node]}  # Can be list or single
+    # Node keeps the last occurrence in `values` and every occurrence in `all_values`
+    root_node.values = {"Material": mat_node}
+    root_node.all_values = {"Material": [mat_node]}
 
     mock_parse.return_value = {"Primitive": root_node}
 

--- a/tests/converters/wireless_insite/test_insite_scene.py
+++ b/tests/converters/wireless_insite/test_insite_scene.py
@@ -2,8 +2,11 @@
 
 from unittest.mock import MagicMock, patch
 
+import numpy as np
+import pytest
+
 from deepmimo.converters.wireless_insite import insite_scene
-from deepmimo.core.scene import CAT_BUILDINGS
+from deepmimo.core.scene import CAT_BUILDINGS, CAT_OBJECTS, get_object_faces
 
 
 def test_extract_objects() -> None:
@@ -60,3 +63,118 @@ def test_read_scene(mock_parser_cls, tmp_path) -> None:
 
     scene = insite_scene.read_scene(tmp_path)
     assert len(scene.objects) == 1
+
+
+# --- Indoor geometry preservation (issue #126) -------------------------------
+
+WALL_AND_DESK_FILE = """
+begin_<structure>
+begin_<sub_structure>
+begin_<face>
+double_sided
+Material 3
+nVertices 4
+-15.9704995849 19.8690896930 0.0000000000
+-15.9704995849 16.4511458519 0.0000000000
+-15.9704995849 16.4511458519 5.0000000000
+-15.9704995849 19.8690896930 5.0000000000
+end_<face>
+end_<sub_structure>
+end_<structure>
+begin_<structure>
+begin_<sub_structure>
+begin_<face>
+Material 0
+nVertices 3
+-19.1732536776 16.7591643727 1.4428974628
+-19.1732536776 17.0385361111 1.2199573755
+-19.1732536776 17.0385361111 1.1795883417
+end_<face>
+end_<sub_structure>
+end_<structure>
+"""
+
+
+def test_object_extension_is_recognized() -> None:
+    """Wireless InSite writes standalone geometry as .object, not .obj."""
+    assert insite_scene.OBJECT_LABELS[".object"] == CAT_OBJECTS
+
+
+def test_extract_object_faces_groups_disconnected_geometry() -> None:
+    """Faces that share no vertices become separate objects, keeping their faces."""
+    objects = insite_scene.extract_object_faces(WALL_AND_DESK_FILE)
+
+    assert len(objects) == 2
+    assert [len(faces) for faces in objects] == [1, 1]
+    # (material index, vertex count) of the single face in each object
+    assert [(faces[0][0], len(faces[0][1])) for faces in objects] == [(3, 4), (0, 3)]
+
+
+def test_extract_object_faces_keeps_vertical_walls() -> None:
+    """A vertical wall projects to a line in xy and must not be dropped.
+
+    The convex-hull path builds objects from their 2D footprint, so a flat wall
+    is discarded as "collinear". Preserving the declared faces keeps it.
+    """
+    wall_vertices = insite_scene.extract_object_faces(WALL_AND_DESK_FILE)[0][0][1]
+    xs = {round(x, 6) for x, _, _ in wall_vertices}
+
+    assert len(xs) == 1  # perfectly vertical
+    assert get_object_faces(np.array(wall_vertices)) is None  # hull path loses it
+
+
+def test_parse_lossless_preserves_geometry(tmp_path) -> None:
+    """Lossless parsing keeps every declared face and maps materials."""
+    file = tmp_path / "room.flp"
+    file.write_text(WALL_AND_DESK_FILE)
+
+    parser = insite_scene.PhysicalObjectParser(
+        str(file),
+        lossless=True,
+        material_map={0: 7, 3: 4},
+    )
+    objects = parser.parse()
+
+    assert len(objects) == 2
+    assert [len(obj.faces) for obj in objects] == [1, 1]
+    assert [obj.faces[0].material_idx for obj in objects] == [4, 7]
+    # exact coordinates, not a hull approximation
+    assert objects[0].faces[0].vertices[0] == pytest.approx(
+        [-15.9704995849, 19.8690896930, 0.0],
+        abs=1e-4,
+    )
+
+
+def test_parse_does_not_accumulate_object_names(tmp_path) -> None:
+    """Object names are derived per object, not appended to the previous one."""
+    file = tmp_path / "room.flp"
+    file.write_text(WALL_AND_DESK_FILE)
+
+    objects = insite_scene.PhysicalObjectParser(str(file), lossless=True).parse()
+
+    assert [obj.name for obj in objects] == ["room_0", "room_1"]
+
+
+def test_extract_object_faces_separates_touching_free_objects() -> None:
+    """Two solids that share no vertices stay separate, as in a .city file.
+
+    Outdoor files declare every building inside a single <structure> block, so
+    grouping by structure would collapse a whole city into one object.
+    """
+    two_triangles = """
+    begin_<face>
+    Material 0
+    nVertices 3
+    0.0000000000 0.0000000000 0.0000000000
+    1.0000000000 0.0000000000 0.0000000000
+    0.0000000000 1.0000000000 0.0000000000
+    end_<face>
+    begin_<face>
+    Material 0
+    nVertices 3
+    50.0000000000 50.0000000000 0.0000000000
+    51.0000000000 50.0000000000 0.0000000000
+    50.0000000000 51.0000000000 0.0000000000
+    end_<face>
+    """
+    assert len(insite_scene.extract_object_faces(two_triangles)) == 2


### PR DESCRIPTION

## Problem

Converting an indoor Wireless InSite scenario (e.g. `I1_2p5`) produced a bare box:
the room's furniture was missing and its walls were replaced by a solid extruded
footprint. The reporter expected "a box with two tables" and got 3 objects / 19
vertices with no tables.

## Root causes

Four separate defects compounded:

1. **`.object` files were never read.** `OBJECT_LABELS` matched `.obj`; Wireless
   InSite writes `.object`. `I1_2p5.setup` lists `StylishDesk.object` and
   `StylishDesk(2).object` as active features, so both tables were dropped at the
   file-glob stage before any parsing happened.
2. **Vertical walls were silently discarded.** The convex-hull path builds each
   object from its 2D xy footprint. A flat wall projects to a line, `ConvexHull`
   raises "collinear", `get_object_faces` returns `None`, and the object is
   skipped. Two of the room's five wall groups vanished this way.
3. **`lossless=True` was a no-op for this converter.** `insite_converter` called
   `read_scene(rt_folder)` without the flag, so the parser had already reduced
   objects to hulls before `export_data(lossless=True)` wrote them out - the
   "lossless" mesh files contained hull boxes.
4. **Materials were truncated to one per file.** `parse_node` overwrote repeated
   labels, so of the four materials `newFlp.flp` declares only the last survived.
   Face material indices are also non-contiguous and unordered (`0, 1, 3, 4` in
   declaration order `0, 1, 2, 3`), so they cannot be inferred from position.

## Changes

- **`insite_scene.py`** - recognise `.object`; add `extract_object_faces()` /
  `parse_face_block()` which keep every declared face and its material instead of
  reducing objects to a vertex bag; add a geometry-preserving parse path behind
  `lossless`; map per-file material indices onto the scenario-wide list via
  `build_material_maps()`; fix object names accumulating across iterations.
- **`insite_materials.py`** - read `.object` files; `parse_materials_with_indices()`
  returns each material with the index it declares; handle PEC materials (declared
  by `.object` files, which have no dielectric layer) and multi-layer dielectrics.
- **`setup_parser.py`** - `Node.all_values` records every occurrence of a repeated
  label. `values` still keeps the last occurrence, so existing readers are
  unaffected; only the material reader opts into the full set.
- **`insite_converter.py`** - pass `lossless` through to `read_scene`.

## Result on `I1_2p5`

| | before | after |
|---|---|---|
| objects | 3 (no tables) | 9 (5 wall groups, 2 desks, 2 ground planes) |
| faces | 18 | 206 |
| materials | 1 | 5 |

Walls, glass panels and wooden floor now carry their real materials, and the room
measures 10.1 x 10.05 m, matching the `<boundary>` in `I1_2p5.setup`.

## Behaviour changes reviewers should know

- **Object names change.** They previously accumulated: on `city_10_austin_3p5`
  the longest name reached 260 characters (`roads_0_1_2_..._173`). They are now
  `roads_0`, `roads_1`, ... Anything keyed on the old names will see new values.
- **`.object` files are now read in hull mode too.** Scenarios shipping `.object`
  files will gain objects that were previously dropped. This is the fix, but it
  changes their output.
- Channel data is untouched in both modes.

## Verification

- `ruff check .`, `ruff format --check .`, `pytest` - all green (716 passed).
- Six new regression tests, including one covering the outdoor case where a whole
  city is declared inside a single `<structure>` block.
- **`city_10_austin_3p5`, full conversion, both modes:** hull output is
  byte-identical to the pre-change converter in geometry, labels and object IDs
  (names are the only difference); hull and lossless agree at 175 objects; and
  pathloss, power, delay and phase are identical between modes across all three
  TX/RX pairs. Pathloss 53.5-174.9 dB, mean 107.0.
- **`i1_2p5`, scene rebuilt** from source and inspected visually.

## Open question

PEC materials are exported as `conductivity = 1e7 S/m`, `permittivity = 1.0`.
There was no existing PEC convention in the codebase; a large finite value keeps
the exported material valid JSON and is numerically equivalent to infinity for
reflection. Happy to change it if you prefer a different representation.


## Also relevant to #125

Defect 2 above is not limited to indoor scenes. In a dense city, adjacent
buildings share walls, so vertex-connectivity grouping merges them into one
object and the convex hull over that cluster becomes a single surface spanning
the scene. In `city_37_seoul_3p5` the largest such object covers 16.6 ha - 46%
of the scene - from 22 faces, which is the "tent" burying the city in the
screenshot on #125.

Converting with `lossless=True` removes it, because the declared faces are kept
and no hull is taken. Note this fixes only that artifact: #125 also needs #129
(concave faces are otherwise fan-triangulated into sprawling sheets), and then a
re-conversion, since neither PR changes already-published `faces.npz`.
