### PR TITLE
Triangulate concave faces by ear clipping (#125)

### DIFF
--- a/deepmimo/core/scene.py
+++ b/deepmimo/core/scene.py
@@ -126,6 +126,175 @@ class BoundingBox:
         )
 
 
+TRIANGLE_VERTEX_COUNT = 3
+
+# Tolerance for the cross-product tests below. Face coordinates are metres, so
+# this treats sub-micrometre turns as straight rather than as real corners.
+_EAR_EPS = 1e-9
+
+
+def _project_to_plane(vertices: np.ndarray) -> np.ndarray:
+    """Project the vertices of a planar face onto 2D coordinates in its own plane.
+
+    The plane is fitted with an SVD rather than taken from the first three
+    vertices, so faces whose leading vertices happen to be collinear still get a
+    usable basis.
+
+    Args:
+        vertices: Array of shape (N, 3).
+
+    Returns:
+        Array of shape (N, 2) with the vertices expressed in the plane's basis.
+
+    """
+    centred = vertices - vertices.mean(axis=0)
+    # Right singular vectors: the first two span the best-fit plane.
+    basis = np.linalg.svd(centred)[2][:2]
+    return centred @ basis.T
+
+
+def _signed_area(points: np.ndarray) -> float:
+    """Return the signed area of a 2D polygon (positive when counter-clockwise).
+
+    Args:
+        points: Array of shape (N, 2).
+
+    Returns:
+        The signed area.
+
+    """
+    x, y = points[:, 0], points[:, 1]
+    return 0.5 * float(np.sum(x * np.roll(y, -1) - np.roll(x, -1) * y))
+
+
+def _is_convex(points: np.ndarray) -> bool:
+    """Check whether a 2D polygon turns the same way at every vertex.
+
+    Args:
+        points: Array of shape (N, 2).
+
+    Returns:
+        True if the polygon is convex.
+
+    """
+    edges = np.roll(points, -1, axis=0) - points
+    cross = edges[:, 0] * np.roll(edges[:, 1], -1) - edges[:, 1] * np.roll(edges[:, 0], -1)
+    return not (np.any(cross > _EAR_EPS) and np.any(cross < -_EAR_EPS))
+
+
+def _fan(vertices: np.ndarray) -> list[np.ndarray]:
+    """Split a convex face into a triangle fan anchored at its first vertex.
+
+    Args:
+        vertices: Array of shape (N, 3).
+
+    Returns:
+        List of (3, 3) triangles.
+
+    """
+    return [
+        np.array([vertices[0], vertices[i], vertices[i + 1]]) for i in range(1, len(vertices) - 1)
+    ]
+
+
+def _point_in_triangle(point: np.ndarray, tri: np.ndarray) -> bool:
+    """Check whether a 2D point lies inside a counter-clockwise triangle.
+
+    Args:
+        point: Array of shape (2,).
+        tri: Array of shape (3, 2), wound counter-clockwise.
+
+    Returns:
+        True if the point is inside or on the triangle.
+
+    """
+    edges = np.roll(tri, -1, axis=0) - tri
+    rel = point - tri
+    cross = edges[:, 0] * rel[:, 1] - edges[:, 1] * rel[:, 0]
+    return bool(np.all(cross >= -_EAR_EPS))
+
+
+def _ear_clip(points: np.ndarray) -> list[list[int]] | None:
+    """Triangulate a simple 2D polygon by ear clipping.
+
+    Args:
+        points: Array of shape (N, 2), wound counter-clockwise.
+
+    Returns:
+        List of index triples into ``points``, or None if the polygon could not
+        be triangulated (self-intersecting or otherwise degenerate).
+
+    """
+    remaining = list(range(len(points)))
+    triangles = []
+
+    while len(remaining) > TRIANGLE_VERTEX_COUNT:
+        for offset in range(len(remaining)):
+            prev_i = remaining[offset - 1]
+            curr_i = remaining[offset]
+            next_i = remaining[(offset + 1) % len(remaining)]
+            tri = points[[prev_i, curr_i, next_i]]
+
+            # Reflex corners cut outside the polygon, so they are never ears.
+            edge_a, edge_b = tri[1] - tri[0], tri[2] - tri[1]
+            if edge_a[0] * edge_b[1] - edge_a[1] * edge_b[0] <= _EAR_EPS:
+                continue
+
+            # A valid ear encloses no other vertex of the polygon.
+            others = [i for i in remaining if i not in (prev_i, curr_i, next_i)]
+            if any(_point_in_triangle(points[i], tri) for i in others):
+                continue
+
+            triangles.append([prev_i, curr_i, next_i])
+            remaining.remove(curr_i)
+            break
+        else:
+            # No ear found: the polygon is not simple.
+            return None
+
+    triangles.append(list(remaining))
+    return triangles
+
+
+def triangulate_polygon(vertices: np.ndarray) -> list[np.ndarray]:
+    """Split a planar polygonal face into triangles that cover exactly its area.
+
+    Convex faces keep the cheap triangle fan. Concave faces are ear clipped, so
+    the triangles follow the outline instead of cutting across its concavities.
+    If ear clipping cannot handle the polygon (self-intersecting, or degenerate
+    after projection) the fan is used as a fallback, matching previous
+    behaviour rather than dropping the face.
+
+    Args:
+        vertices: Array of shape (N, 3) describing one planar face.
+
+    Returns:
+        List of (3, 3) triangles.
+
+    """
+    vertices = np.asarray(vertices)
+    if len(vertices) < TRIANGLE_VERTEX_COUNT:
+        return []
+    if len(vertices) == TRIANGLE_VERTEX_COUNT:
+        return [vertices]
+
+    points = _project_to_plane(vertices.astype(float))
+    if _is_convex(points):
+        return _fan(vertices)
+
+    # Ear clipping assumes a counter-clockwise winding.
+    flipped = _signed_area(points) < 0
+    if flipped:
+        points = points[::-1]
+
+    triangles = _ear_clip(points)
+    if triangles is None:
+        return _fan(vertices)
+
+    order = list(range(len(vertices)))[::-1] if flipped else list(range(len(vertices)))
+    return [np.array([vertices[order[i]] for i in tri]) for tri in triangles]
+
+
 class Face:
     """Represents a single face (surface) of a physical object.
 
@@ -139,7 +308,7 @@ class Face:
     - Available through triangular_faces property
     - Better for detailed visualization
     - Preserves exact geometry when needed
-    - Generated using fan triangulation
+    - Generated by :func:`triangulate_polygon`
 
     This dual representation allows the system to be efficient while maintaining
     the ability to represent detailed geometry when required.
@@ -177,17 +346,16 @@ class Face:
 
     @property
     def triangular_faces(self) -> list[np.ndarray]:
-        """Get the triangular faces that make up this face."""
+        """Get the triangular faces that make up this face.
+
+        Convex faces are split with a triangle fan from the first vertex, which
+        tiles them exactly. Concave faces are ear clipped instead: a fan from a
+        single vertex would emit triangles crossing the concavities, covering
+        area the face does not occupy (a 182-vertex block outline in a published
+        city scenario inflated by ~10x this way).
+        """
         if self._triangular_faces is None:
-            tri_vertex_count = 3
-            if len(self.vertices) == tri_vertex_count:
-                self._triangular_faces = [self.vertices]
-            else:
-                triangles = []
-                for i in range(1, len(self.vertices) - 1):
-                    triangle = np.array([self.vertices[0], self.vertices[i], self.vertices[i + 1]])
-                    triangles.append(triangle)
-                self._triangular_faces = triangles
+            self._triangular_faces = triangulate_polygon(self.vertices)
         return self._triangular_faces
 
     @property

--- a/tests/core/test_scene.py
+++ b/tests/core/test_scene.py
@@ -24,6 +24,7 @@ from deepmimo.core.scene import (
     Scene,
     _get_faces_convex_hull,
     get_object_faces,
+    triangulate_polygon,
 )
 from deepmimo.utils import save_dict_as_json
 
@@ -548,3 +549,91 @@ def test_get_object_faces_too_few_vertices() -> None:
     """Fewer than 3 vertices returns None."""
     result = get_object_faces([[0, 0, 0], [1, 0, 0]])
     assert result is None
+
+
+# --- Polygon triangulation (issue #125) --------------------------------------
+
+
+def _polygon_area_2d(points: np.ndarray) -> float:
+    """Return the absolute area of a 2D polygon via the shoelace formula."""
+    x, y = points[:, 0], points[:, 1]
+    return abs(0.5 * float(np.sum(x * np.roll(y, -1) - np.roll(x, -1) * y)))
+
+
+def _triangulated_area(triangles: list[np.ndarray]) -> float:
+    """Return the summed area of triangles, using their first two coordinates."""
+    return sum(_polygon_area_2d(tri[:, :2]) for tri in triangles)
+
+
+# A U: vertex 0 cannot see into the far arm, so a fan anchored there spans the
+# notch between the arms and over-reports the area (11 units instead of 7).
+U_SHAPE = np.array(
+    [[0, 0, 0], [3, 0, 0], [3, 3, 0], [2, 3, 0], [2, 1, 0], [1, 1, 0], [1, 3, 0], [0, 3, 0]],
+    dtype=float,
+)
+HEXAGON = np.array(
+    [[np.cos(a), np.sin(a), 0.0] for a in np.linspace(0, 2 * np.pi, 7)[:-1]],
+    dtype=float,
+)
+
+
+def test_triangulate_convex_polygon_is_a_fan() -> None:
+    """Convex faces keep the cheap fan anchored at the first vertex."""
+    triangles = triangulate_polygon(HEXAGON)
+
+    expected = [np.array([HEXAGON[0], HEXAGON[i], HEXAGON[i + 1]]) for i in range(1, 5)]
+    assert len(triangles) == len(expected)
+    for actual, want in zip(triangles, expected, strict=True):
+        assert np.array_equal(actual, want)
+
+
+def test_triangulate_concave_polygon_covers_exact_area() -> None:
+    """Ear clipping tiles a concave face without spilling into its notch."""
+    triangles = triangulate_polygon(U_SHAPE)
+
+    assert len(triangles) == len(U_SHAPE) - 2
+    assert _triangulated_area(triangles) == pytest.approx(_polygon_area_2d(U_SHAPE[:, :2]))
+
+
+def test_triangulate_concave_polygon_beats_naive_fan() -> None:
+    """The naive fan really does over-report this polygon, so the test has teeth."""
+    fan = [np.array([U_SHAPE[0], U_SHAPE[i], U_SHAPE[i + 1]]) for i in range(1, len(U_SHAPE) - 1)]
+
+    assert _triangulated_area(fan) > _polygon_area_2d(U_SHAPE[:, :2])
+
+
+def test_triangulate_handles_clockwise_winding() -> None:
+    """Winding order must not change the triangulated area."""
+    triangles = triangulate_polygon(U_SHAPE[::-1])
+
+    assert _triangulated_area(triangles) == pytest.approx(_polygon_area_2d(U_SHAPE[:, :2]))
+
+
+def test_triangulate_vertical_polygon() -> None:
+    """Faces are projected onto their own plane, so vertical walls work too."""
+    # The U-shape rotated into the x=0 plane.
+    wall = U_SHAPE[:, [2, 0, 1]]
+
+    triangles = triangulate_polygon(wall)
+
+    assert len(triangles) == len(wall) - 2
+    assert _triangulated_area([tri[:, 1:] for tri in triangles]) == pytest.approx(
+        _polygon_area_2d(U_SHAPE[:, :2]),
+    )
+
+
+def test_triangulate_degenerate_inputs() -> None:
+    """Triangles pass through unchanged; anything smaller yields nothing."""
+    triangle = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=float)
+
+    assert len(triangulate_polygon(triangle)) == 1
+    assert triangulate_polygon(np.zeros((2, 3))) == []
+
+
+def test_face_triangular_faces_uses_exact_triangulation() -> None:
+    """Face.triangular_faces routes through the shared triangulator."""
+    face = Face(vertices=U_SHAPE)
+
+    assert _triangulated_area(face.triangular_faces) == pytest.approx(
+        _polygon_area_2d(U_SHAPE[:, :2]),
+    )


### PR DESCRIPTION
## Problem

Reported in #125: the geometry mesh looks corrupted in some cities, e.g.
`city_37_seoul_3p5`.

Investigating that scenario against its Wireless InSite source turned up **two
independent defects**. This PR fixes the second; the first is #128.

| artifact | cause | fixed by |
|---|---|---|
| a single hull "tent" spanning the whole scene | convex hull taken over a merged cluster of buildings | #128 (`lossless=True` keeps the declared faces) |
| sheets spraying out from single vertices | fan triangulation of concave polygons | **this PR** |

## This PR: fan triangulation

`Face.triangular_faces` split every polygon into a triangle fan anchored at
vertex 0:

```python
for i in range(1, len(self.vertices) - 1):
    triangle = np.array([self.vertices[0], self.vertices[i], self.vertices[i + 1]])
```

A fan tiles a convex polygon exactly. On a concave one, vertex 0 cannot see the
whole interior, so the fan emits triangles that cut across the concavities and
cover area the face does not occupy.

`buildings.city` in `city_37_seoul_3p5` traces block outlines as single flat
polygons - the largest has **182 vertices and spans 426 m**. Fanned from vertex
0 it reports **57,307 m² instead of 5,835 m², a factor of 9.8**. Across that
file the flat polygons cover 10.84 ha but triangulate to 30.29 ha.

Two notes on where this shows up. It affects the mesh export directly, since
`to_mesh_arrays` builds `faces.npz` from `triangular_faces` - which is what the
web visualizer consumes. But `Scene.plot()` defaults to `mode="faces"`, drawing
the polygons directly, so a local plot looks fine and only `mode="tri_faces"`
reproduces it. And it is not converter-specific: any face with a concave outline
is affected, whichever ray tracer produced it.

## Change

Concave faces are ear clipped instead. Faces are projected onto their own
best-fit plane first (SVD rather than the first three vertices, so leading
collinear vertices are fine), which makes vertical walls work as readily as
ground polygons, and the winding is normalised so either orientation triangulates.

Convex faces keep the existing fan, so their output is bit-for-bit unchanged: of
1560 faces across the Seoul and Austin sources, only the 102 concave ones differ.
A polygon that cannot be ear clipped (self-intersecting, or degenerate after
projection) falls back to the fan rather than being dropped, so no face is ever
lost.

No new dependency - the ear clipper is about 40 lines. If you would rather take
`mapbox_earcut` for speed and hole support, the entry point is a single function
and easy to swap.

## Verification

Triangulated area now equals the shoelace area of the outline exactly:

| file | outline | before | after |
|---|---|---|---|
| Seoul `buildings.city` | 10.84 ha | 30.29 ha | **10.84 ha** (ratio 1.00000) |
| Austin `buildings.city` | 3.48 ha | 3.48 ha | 3.48 ha |
| Austin `roads.city` | 3.48 ha | 3.48 ha | 3.48 ha |

Every face still yields exactly n-2 triangles. Seven new tests cover the convex
fan being preserved, exact area on a concave U (where a fan reports 11 units
against a true 7), both winding orders, vertical faces, and degenerate inputs.

`ruff check .`, `ruff format --check .` and `pytest` all pass (717 tests).

This branch is cut from `main` and is independent of #128 - they touch different
files and can merge in either order. Merged locally, the two produce a clean
Seoul scene and all 717 tests still pass.

## Scope

Fully resolving #125 needs **both** PRs, and then a re-conversion: neither
changes the `faces.npz` already published for affected scenarios.

Two further observations from the same data, not addressed here:

- 177 of 215 objects in Seoul have zero height. These are flat outlines in the
  source rather than a converter defect, but they are labelled `buildings`.
- Those large flat polygons touch many buildings, so vertex-connectivity
  grouping merges them into one 668 m object covering 46% of the scene. #128
  stops that merge from being hulled into a tent, but the grouping itself
  remains a modelling question worth deciding separately.
