### PR TITLE
Bump version to 4.0.4

### DIFF
--- a/deepmimo/__init__.py
+++ b/deepmimo/__init__.py
@@ -1,6 +1,6 @@
 """DeepMIMO Python Package."""
 
-__version__ = "4.0.3"
+__version__ = "4.0.4"
 
 # Core functionality
 # Import immediate modules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "DeepMIMO"
-version = "4.0.3"
+version = "4.0.4"
 authors = [
     { name = "João Morais" },
     { name = "Umut Demirhan" },


### PR DESCRIPTION
## Summary
- Bump package version 4.0.3 -> 4.0.4 in pyproject.toml and deepmimo/__init__.py, ahead of pip package upload.

## Test plan
- [x] uv build succeeds, produces wheel + sdist