### PR TITLE
Align steering_vec and spherical utils with the polar angle convention (#63)

### DIFF
--- a/deepmimo/converters/aodt/aodt_paths.py
+++ b/deepmimo/converters/aodt/aodt_paths.py
@@ -216,18 +216,21 @@ def read_paths(  # noqa: C901, PLR0912, PLR0915
                         data[c.TX_POS_PARAM_NAME][0] = tx_pos
                     data[c.RX_POS_PARAM_NAME][rx_idx] = rx_pos
 
-                # Calculate angles
+                # Calculate angles. cartesian_to_spherical returns (r, theta, phi) where
+                # theta is the polar angle from +z and phi the azimuth from +x, which is
+                # the convention the *_el / *_az dataset arrays use (see
+                # docs/resources/conventions.md).
                 # Departure angles - vector from TX to first interaction point
                 departure_vector = interaction_points[1] - tx_pos
                 departure_angles = gu.cartesian_to_spherical(departure_vector.reshape(1, -1))[0]
-                data[c.AOD_AZ_PARAM_NAME][rx_idx, path_idx] = np.rad2deg(departure_angles[1])
-                data[c.AOD_EL_PARAM_NAME][rx_idx, path_idx] = np.rad2deg(departure_angles[2])
+                data[c.AOD_EL_PARAM_NAME][rx_idx, path_idx] = np.rad2deg(departure_angles[1])
+                data[c.AOD_AZ_PARAM_NAME][rx_idx, path_idx] = np.rad2deg(departure_angles[2])
 
                 # Arrival angles - vector from last interaction point to RX
                 arrival_vector = rx_pos - interaction_points[-2]
                 arrival_angles = gu.cartesian_to_spherical(arrival_vector.reshape(1, -1))[0]
-                data[c.AOA_AZ_PARAM_NAME][rx_idx, path_idx] = np.rad2deg(arrival_angles[1])
-                data[c.AOA_EL_PARAM_NAME][rx_idx, path_idx] = np.rad2deg(arrival_angles[2])
+                data[c.AOA_EL_PARAM_NAME][rx_idx, path_idx] = np.rad2deg(arrival_angles[1])
+                data[c.AOA_AZ_PARAM_NAME][rx_idx, path_idx] = np.rad2deg(arrival_angles[2])
 
                 # Store interaction data - skip first (TX) and last (RX) points
                 actual_interactions = interaction_points[1:-1]

--- a/deepmimo/generator/geometry.py
+++ b/deepmimo/generator/geometry.py
@@ -368,24 +368,61 @@ def _rotate_angles_batch(
     )
 
 
-def steering_vec(array: NDArray, phi: float = 0, theta: float = 0, spacing: float = 0.5) -> NDArray:
+def steering_vec(
+    array: NDArray,
+    phi: float = 0,
+    theta: float | None = None,
+    spacing: float = 0.5,
+    angle_convention: str = "polar",
+) -> NDArray:
     """Calculate the steering vector for an antenna array.
 
     This function computes the normalized array response vector for a given array
     geometry and steering direction.
 
+    By default ``theta`` uses the same convention as the rest of DeepMIMO: the polar
+    angle measured from +z (see ``docs/resources/conventions.md``). Dataset angles such
+    as ``dataset.aoa_el`` / ``dataset.aod_el`` can therefore be passed straight in, and
+    the result matches the array response used to build the channel.
+
     Args:
-        array (NDArray): Array of antenna positions
+        array (NDArray): Panel size as (horizontal, vertical) number of elements.
         phi (float): Azimuth angle in degrees. (0°=+x, 90°=+y) Defaults to 0.
-        theta (float): Elevation angle in degrees. (0°=xy-plane, 90°=+z) Defaults to 0.
+        theta (float | None): Vertical angle in degrees, interpreted according to
+            ``angle_convention``. Defaults to the xy-plane (90° for ``"polar"``,
+            0° for ``"elevation"``).
         spacing (float): Antenna spacing in wavelengths. Defaults to 0.5.
+        angle_convention (str): How ``theta`` is measured. ``"polar"`` (default) measures
+            it from +z (0°=+z, 90°=xy-plane, 180°=-z), matching the dataset angles and
+            the internal array response. ``"elevation"`` measures it up from the xy-plane
+            (0°=xy-plane, 90°=+z).
 
     Returns:
         NDArray: Complex normalized steering (array response) vector
 
+    Raises:
+        ValueError: If ``angle_convention`` is not ``"polar"`` or ``"elevation"``.
+
+    Note:
+        This is a behavior change: ``theta`` was previously always treated as an
+        elevation angle, which disagreed with the polar angles stored in the dataset and
+        produced a mismatched array manifold (see issue #63). Pass
+        ``angle_convention="elevation"`` to keep the old interpretation.
+
     """
-    idxs = _ant_indices(array)
-    theta_polar = np.pi / 2 - np.deg2rad(theta)  # convert elevation -> polar
+    if angle_convention not in ("polar", "elevation"):
+        msg = f"angle_convention must be 'polar' or 'elevation', got {angle_convention!r}."
+        raise ValueError(msg)
+
+    if theta is None:
+        theta = 90.0 if angle_convention == "polar" else 0.0
+
+    theta_polar = (
+        np.deg2rad(theta)
+        if angle_convention == "polar"
+        else np.pi / 2 - np.deg2rad(theta)  # convert elevation -> polar
+    )
     phi_rad = np.deg2rad(phi)
+    idxs = _ant_indices(array)
     resp = _array_response(idxs, theta_polar, phi_rad, 2 * np.pi * spacing)
     return resp / np.linalg.norm(resp)

--- a/deepmimo/utils/geometry.py
+++ b/deepmimo/utils/geometry.py
@@ -1,6 +1,21 @@
 """Geometry utilities for DeepMIMO.
 
 This module provides functions for coordinate transformations and geometric calculations.
+
+Angle convention
+----------------
+Both conversions below use the DeepMIMO spherical convention documented in
+``docs/resources/conventions.md``, matching the dataset angle arrays
+(``aoa_el``/``aod_el`` and ``aoa_az``/``aod_az``) and the array-response code in
+``deepmimo.generator.geometry``:
+
+- ``theta`` is the polar (inclination) angle measured from +z: 0 at +z, pi/2 in the
+  xy-plane, pi at -z. Despite the historical ``_el`` suffix on the dataset arrays, this
+  is *not* an elevation measured up from the horizon.
+- ``phi`` is the azimuth measured counter-clockwise from +x in the xy-plane.
+
+Both functions order their triples as ``(r, theta, phi)`` so that they are exact
+inverses of one another.
 """
 
 import numpy as np
@@ -10,18 +25,32 @@ def cartesian_to_spherical(cartesian_coords: np.ndarray) -> np.ndarray:
     """Convert Cartesian coordinates to spherical coordinates.
 
     Args:
-        cartesian_coords: Array [n_points, 3] of Cartesian coordinates (x, y, z)
+        cartesian_coords: Array of Cartesian coordinates (x, y, z). Leading dimensions
+            are allowed; the last dimension must be 3.
 
     Returns:
-        Array [n_points, 3] of spherical coordinates (r, azimuth, elevation) in radians.
-        r is the magnitude (distance from origin).
+        Array of the same shape containing spherical coordinates (r, theta, phi), with
+        the angles in radians. ``r`` is the distance from the origin, ``theta`` is the
+        polar angle from +z in [0, pi] and ``phi`` is the azimuth from +x in (-pi, pi].
+        This is the exact inverse of :func:`spherical_to_cartesian`.
+
+    Note:
+        This is a behavior change: the returned triple is now ordered ``(r, theta, phi)``.
+        It was previously ``(r, phi, elevation_from_xy_plane)``, which was neither the
+        library's documented angle convention nor the inverse of
+        :func:`spherical_to_cartesian` (see issue #63).
 
     """
-    spherical_coords = np.zeros((cartesian_coords.shape[0], 3))
-    spherical_coords[:, 0] = np.sqrt(np.sum(cartesian_coords**2, axis=1))
-    spherical_coords[:, 1] = np.arctan2(cartesian_coords[:, 1], cartesian_coords[:, 0])
-    r_xy = np.sqrt(cartesian_coords[:, 0] ** 2 + cartesian_coords[:, 1] ** 2)
-    spherical_coords[:, 2] = np.arctan2(cartesian_coords[:, 2], r_xy)
+    cartesian_coords = np.asarray(cartesian_coords, dtype=float)
+    x = cartesian_coords[..., 0]
+    y = cartesian_coords[..., 1]
+    z = cartesian_coords[..., 2]
+
+    r_xy = np.hypot(x, y)
+    spherical_coords = np.zeros_like(cartesian_coords)
+    spherical_coords[..., 0] = np.hypot(r_xy, z)
+    spherical_coords[..., 1] = np.arctan2(r_xy, z)
+    spherical_coords[..., 2] = np.arctan2(y, x)
     return spherical_coords
 
 
@@ -29,21 +58,23 @@ def spherical_to_cartesian(spherical_coords: np.ndarray) -> np.ndarray:
     """Convert spherical coordinates to Cartesian coordinates.
 
     Args:
-        spherical_coords: Array with spherical coordinates (r, elevation, azimuth) in radians.
-            r is the magnitude (distance from origin). Leading dimensions allowed; last
-            dimension must be 3.
+        spherical_coords: Array with spherical coordinates (r, theta, phi), with the
+            angles in radians. ``r`` is the distance from the origin, ``theta`` is the
+            polar angle from +z and ``phi`` is the azimuth from +x. Leading dimensions
+            are allowed; the last dimension must be 3.
             Reference: https://en.wikipedia.org/wiki/Spherical_coordinate_system
-            Note: DeepMIMO uses elevation from the xy plane, while Sionna/Wikipedia use z-axis.
 
     Returns:
-        Array of same shape containing Cartesian coordinates (x, y, z).
+        Array of the same shape containing Cartesian coordinates (x, y, z).
 
     """
-    cartesian_coords = np.zeros_like(spherical_coords)
+    spherical_coords = np.asarray(spherical_coords, dtype=float)
     r = spherical_coords[..., 0]
-    elevation = spherical_coords[..., 1]
-    azimuth = spherical_coords[..., 2]
-    cartesian_coords[..., 0] = r * np.sin(elevation) * np.cos(azimuth)
-    cartesian_coords[..., 1] = r * np.sin(elevation) * np.sin(azimuth)
-    cartesian_coords[..., 2] = r * np.cos(elevation)
+    theta = spherical_coords[..., 1]
+    phi = spherical_coords[..., 2]
+
+    cartesian_coords = np.zeros_like(spherical_coords)
+    cartesian_coords[..., 0] = r * np.sin(theta) * np.cos(phi)
+    cartesian_coords[..., 1] = r * np.sin(theta) * np.sin(phi)
+    cartesian_coords[..., 2] = r * np.cos(theta)
     return cartesian_coords

--- a/tests/generator/test_geometry.py
+++ b/tests/generator/test_geometry.py
@@ -200,6 +200,57 @@ def test_steering_vec_properties() -> None:
     np.testing.assert_allclose(np.linalg.norm(vec), 1.0, rtol=1e-12, atol=1e-12)
 
 
+def test_steering_vec_matches_channel_array_response() -> None:
+    """steering_vec must reproduce the manifold the channel generator builds.
+
+    Regression test for issue #63: dataset angles (aoa_el/aod_el) are polar angles
+    measured from +z, so feeding them to steering_vec has to yield exactly the array
+    response used to synthesize the channel.
+    """
+    panel_size = (1, 8)  # vertical ULA -> the response depends strongly on theta
+    spacing = 0.5
+    kd = 2 * np.pi * spacing
+    idxs = ant_indices(panel_size)
+
+    # Angles exactly as a Dataset stores them: degrees, polar measured from +z.
+    for aoa_el, aoa_az in [(30.0, 45.0), (75.0, 10.0), (120.0, 200.0), (90.0, 0.0)]:
+        expected = array_response(idxs, np.deg2rad(aoa_el), np.deg2rad(aoa_az), kd).ravel()
+        expected = expected / np.linalg.norm(expected)
+        got = steering_vec(panel_size, phi=aoa_az, theta=aoa_el, spacing=spacing).ravel()
+
+        np.testing.assert_allclose(got, expected, rtol=1e-12, atol=1e-12)
+        assert abs(np.vdot(got, expected)) == pytest.approx(1.0, abs=1e-12)
+
+
+def test_steering_vec_elevation_convention_is_complement() -> None:
+    """The elevation convention must match the polar convention at 90 - theta."""
+    panel_size = (2, 4)
+    for theta_el in (-40.0, 0.0, 25.0, 60.0):
+        polar = steering_vec(panel_size, phi=15.0, theta=90.0 - theta_el)
+        elevation = steering_vec(panel_size, phi=15.0, theta=theta_el, angle_convention="elevation")
+        np.testing.assert_allclose(elevation, polar, rtol=1e-12, atol=1e-12)
+
+
+def test_steering_vec_default_theta_is_xy_plane() -> None:
+    """Azimuth-only calls keep steering along the xy-plane under either convention."""
+    panel_size = (4, 2)
+    horizon = steering_vec(panel_size, phi=30.0, theta=90.0)
+
+    np.testing.assert_allclose(steering_vec(panel_size, phi=30.0), horizon, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(
+        steering_vec(panel_size, phi=30.0, angle_convention="elevation"),
+        horizon,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+def test_steering_vec_rejects_unknown_convention() -> None:
+    """An unrecognized angle convention is rejected instead of silently ignored."""
+    with pytest.raises(ValueError, match="angle_convention"):
+        steering_vec((2, 2), phi=0.0, theta=45.0, angle_convention="zenith")
+
+
 def test_ant_indices() -> None:
     """Test antenna indices generation."""
     panel_size = [6, 4]

--- a/tests/utils/test_general_utils.py
+++ b/tests/utils/test_general_utils.py
@@ -133,38 +133,36 @@ def test_dot_dict() -> None:
 
 
 def test_coordinate_conversion() -> None:
-    """Test coordinate conversion functions."""
-    # Test cartesian to spherical
+    """Test coordinate conversion functions.
+
+    Both helpers use the DeepMIMO convention (docs/resources/conventions.md): triples are
+    ordered (r, theta, phi) with theta the polar angle from +z and phi the azimuth from
+    +x. Regression test for issue #63, where the two were neither mutually consistent nor
+    inverses of each other.
+    """
     cart = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
     sph = general_utils.cartesian_to_spherical(cart)
 
-    # Point (1,0,0): r=1, az=0, el=0
-    assert np.allclose(sph[0], [1, 0, 0])
+    # Point (1,0,0): r=1, theta=pi/2 (xy-plane), phi=0
+    assert np.allclose(sph[0], [1, np.pi / 2, 0])
 
-    # Point (0,1,0): r=1, az=pi/2, el=0
-    assert np.allclose(sph[1], [1, np.pi / 2, 0])
+    # Point (0,1,0): r=1, theta=pi/2 (xy-plane), phi=pi/2
+    assert np.allclose(sph[1], [1, np.pi / 2, np.pi / 2])
 
-    # Point (0,0,1): r=1, az=0 (undefined), el=pi/2
+    # Point (0,0,1): r=1, theta=0 (+z), phi undefined (0)
     assert np.isclose(sph[2, 0], 1)
-    assert np.isclose(sph[2, 2], np.pi / 2)
+    assert np.isclose(sph[2, 1], 0)
 
-    # Test spherical to cartesian (inverse)
-    # NOTE: spherical_to_cartesian expects inclination (from z-axis) but
-    # cartesian_to_spherical returns elevation (from xy-plane). Convert before testing inverse.
-    sph_for_inverse = sph.copy()
-    sph_for_inverse[..., 1] = (
-        np.pi / 2 - sph[..., 2]
-    )  # Inclination = pi/2 - Elevation (if Elevation is from horizon)
-    # cartesian_to_spherical returns (r, az, el); spherical_to_cartesian expects (r, inc, az).
-    # Implementation treats "elevation" as inclination, so swap indices and convert el->inc.
-
-    sph_input = np.zeros_like(sph)
-    sph_input[..., 0] = sph[..., 0]  # r
-    sph_input[..., 1] = np.pi / 2 - sph[..., 2]  # inclination from z = pi/2 - elevation from xy
-    sph_input[..., 2] = sph[..., 1]  # azimuth
-
-    back_cart = general_utils.spherical_to_cartesian(sph_input)
+    # The conversions are exact inverses -- no reordering or angle fix-up needed.
+    back_cart = general_utils.spherical_to_cartesian(sph)
     assert np.allclose(back_cart, cart, atol=1e-7)
+
+    rng = np.random.default_rng(0)
+    points = rng.standard_normal((50, 3))
+    round_tripped = general_utils.spherical_to_cartesian(
+        general_utils.cartesian_to_spherical(points)
+    )
+    assert np.allclose(round_tripped, points, atol=1e-10)
 
 
 def test_delegating_list() -> None:


### PR DESCRIPTION
## Summary

Fixes #63. DeepMIMO stores `theta` as a polar angle from +z (see `docs/resources/conventions.md`; published scenarios have `aoa_el` in `[0, 180]`). The array response, angle rotation, FoV filtering and dipole pattern all follow that convention — three places did not.

- **`steering_vec()`** applied `theta_polar = pi/2 - theta`, so dataset angles produced a mismatched manifold. For an 8-element vertical ULA at `aoa_el=30`, `aoa_az=45`, correlation with the array response actually used to build the channel was **0.228** instead of 1.0 (≈ −12.8 dB of array gain; the manifold points 30° off, landing past the first null).
- **`cartesian_to_spherical()`** returned `(r, azimuth, elevation-from-xy)` while **`spherical_to_cartesian()`** expected `(r, polar-from-z, azimuth)` — neither mutually consistent nor inverses. Round-tripping `(1, 2, 3)` gave `(2.0, 2.68, 1.67)`: same norm, 27.8° off, so nothing downstream flags it.
- **The AODT converter** stored the elevation-from-xy component in `aoa_el`/`aod_el`, giving `[-90, 90]` where the Sionna and Wireless InSite converters give `[0, 180]`. AODT scenarios had incorrect array responses and antenna pattern gains.

## Changes

- `steering_vec()`: `theta` is now polar, so `dataset.aoa_el` can be passed directly. Added `angle_convention="polar"|"elevation"` for the old interpretation.
- `cartesian_to_spherical` / `spherical_to_cartesian`: both use `(r, theta, phi)` with theta polar from +z; now exact inverses.
- AODT converter: stores the polar component, matching the other converters. Azimuth unchanged.
- Regression tests for manifold agreement, convention equivalence, the azimuth-only default, and an exact spherical round-trip.

## Compatibility

- **Azimuth-only `steering_vec()` calls are unchanged.** `theta` now defaults to `None`, resolving to the xy-plane under either convention (90° polar / 0° elevation) — so every tutorial and docs example is bit-identical. Callers who explicitly passed elevation should add `angle_convention="elevation"`.
- **Breaking:** `cartesian_to_spherical()`'s return order changed. It is exported in `deepmimo.utils.__all__`; the AODT converter was its only in-tree user.
- **Existing AODT-converted scenarios need re-conversion** — their stored elevation angles are in the wrong convention.

## Testing

767 passed, 10 skipped. `ruff check` and `ruff format` clean.

## Open questions for review

1. Is the `cartesian_to_spherical()` return-order break acceptable in a patch release, or should it wait for a minor version?
2. Could someone with an AODT scenario spot-check the converter change? I had none available locally.
3. `angle_convention="polar"` reads ambiguously (it names the *polar angle*, not polar-vs-Cartesian coordinates). Happy to rename the option to `"zenith"` (matching 3GPP ZoA/ZoD) or `"inclination"` if reviewers prefer.
4. Out of scope here, but the root cause is the `*_el` name: the dataset arrays hold polar angles, and `docs/quickstart.md`, `docs/resources/specs.md` and `docs/api/datasets.md` all describe them as "elevation". A follow-up renaming `*_el` → `*_theta` (with aliases) plus a docs sweep would close the ambiguity properly.